### PR TITLE
Improve minimalist UI accessibility

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -44,7 +44,9 @@ export default async function DashboardLayout({
           </nav>
         </div>
       </header>
-      <main className="flex-1 p-4">{children}</main>
+      <main id="main-content" tabIndex={-1} className="flex-1 p-4">
+        {children}
+      </main>
     </div>
   )
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,13 +2,19 @@ import { createClient } from "@/lib/supabase/server"
 import { redirect } from "next/navigation"
 import { DashboardActions } from "@/components/dashboard-actions"
 import { HostEndTableButton } from "@/components/host-end-table-button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import Link from "next/link"
 
 // Add short cache for faster back/forward navigation
-export const dynamic = 'force-dynamic'
-export const revalidate = 30  // 30 seconds
+export const dynamic = "force-dynamic"
+export const revalidate = 30 // 30 seconds
 
 export default async function DashboardPage() {
   const supabase = await createClient()
@@ -20,7 +26,9 @@ export default async function DashboardPage() {
   // Get user's game memberships
   const { data: membershipsRaw } = await supabase
     .from("game_players")
-    .select("status, game:games!inner(id, short_code, description, status, host_id)")
+    .select(
+      "status, game:games!inner(id, short_code, description, status, host_id)"
+    )
     .eq("user_id", user.id)
     .neq("status", "pending")
     .in("games.status", ["active", "closed"])
@@ -53,60 +61,89 @@ export default async function DashboardPage() {
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-2">
-            {memberships.map((m: { status: string; game: { id: string; short_code: string; description: string; status: string; host_id: string } | { id: string; short_code: string; description: string; status: string; host_id: string }[] | null }) => {
-              const game = Array.isArray(m.game) ? m.game[0] : m.game
-              if (!game) return null
-              const isHost = game.host_id === user.id
-              const isDenied = m.status === "denied"
-              const roleLabel = isHost
-                ? "Host"
-                : m.status === "approved"
-                  ? "Player"
-                  : isDenied
-                    ? "Removed"
-                    : "Pending"
+            {memberships.map(
+              (m: {
+                status: string
+                game:
+                  | {
+                      id: string
+                      short_code: string
+                      description: string
+                      status: string
+                      host_id: string
+                    }
+                  | {
+                      id: string
+                      short_code: string
+                      description: string
+                      status: string
+                      host_id: string
+                    }[]
+                  | null
+              }) => {
+                const game = Array.isArray(m.game) ? m.game[0] : m.game
+                if (!game) return null
+                const isHost = game.host_id === user.id
+                const isDenied = m.status === "denied"
+                const roleLabel = isHost
+                  ? "Host"
+                  : m.status === "approved"
+                    ? "Player"
+                    : isDenied
+                      ? "Removed"
+                      : "Pending"
 
-              return (
-                <div
-                  key={game.id}
-                  className={`flex items-center justify-between rounded border px-3 py-2 text-sm ${isDenied ? "border-red-500/20 bg-red-500/5 opacity-75" : ""
+                return (
+                  <div
+                    key={game.id}
+                    className={`flex items-center justify-between rounded border px-3 py-2 text-sm ${
+                      isDenied
+                        ? "border-red-500/20 bg-red-500/5 opacity-75"
+                        : ""
                     }`}
-                >
-                  <div>
-                    <p className="font-medium">
-                      {game.description || "Game"}{" "}
-                      <span className={`ml-1 text-xs ${isDenied ? "text-red-400" : "text-muted-foreground"
-                        }`}>
-                        ({roleLabel})
-                      </span>
-                    </p>
-                    <p className="text-muted-foreground text-xs">
-                      ID: <span className="font-mono">{game.short_code}</span>
-                    </p>
-                    {isDenied && (
-                      <p className="text-red-400/80 text-xs mt-0.5">
-                        You were removed — open the game to request to rejoin.
+                  >
+                    <div>
+                      <p className="font-medium">
+                        {game.description || "Game"}{" "}
+                        <span
+                          className={`ml-1 text-xs ${
+                            isDenied
+                              ? "text-destructive"
+                              : "text-muted-foreground"
+                          }`}
+                        >
+                          ({roleLabel})
+                        </span>
                       </p>
-                    )}
+                      <p className="text-muted-foreground text-xs">
+                        ID: <span className="font-mono">{game.short_code}</span>
+                      </p>
+                      {isDenied && (
+                        <p className="text-destructive text-xs mt-0.5">
+                          You were removed — open the game to request to rejoin.
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Button asChild size="sm" variant="outline">
+                        <Link href={`/game/${game.id}`} prefetch={true}>
+                          Open
+                        </Link>
+                      </Button>
+                      {isHost && (
+                        <HostEndTableButton
+                          gameId={game.id}
+                          tableName={game.description ?? ""}
+                        />
+                      )}
+                    </div>
                   </div>
-                  <div className="flex items-center gap-2">
-                    <Button asChild size="sm" variant="outline">
-                      <Link href={`/game/${game.id}`} prefetch={true}>Open</Link>
-                    </Button>
-                    {isHost && (
-                      <HostEndTableButton
-                        gameId={game.id}
-                        tableName={game.description ?? ""}
-                      />
-                    )}
-                  </div>
-                </div>
-              )
-            })}
+                )
+              }
+            )}
           </CardContent>
         </Card>
       )}
-
     </div>
   )
 }

--- a/app/game/[gameId]/layout.tsx
+++ b/app/game/[gameId]/layout.tsx
@@ -45,7 +45,9 @@ export default async function GameLayout({
         <div className="mx-auto flex max-w-4xl items-center justify-between px-4 py-3">
           <div className="flex items-center gap-3">
             <Link href="/dashboard">
-              <Button variant="ghost" size="sm">Dashboard</Button>
+              <Button variant="ghost" size="sm">
+                Dashboard
+              </Button>
             </Link>
             <span className="text-muted-foreground">/</span>
             <Link
@@ -68,8 +70,9 @@ export default async function GameLayout({
           </Link>
         </div>
       </header>
-      <main className="flex-1 p-4">{children}</main>
+      <main id="main-content" tabIndex={-1} className="flex-1 p-4">
+        {children}
+      </main>
     </div>
   )
 }
-

--- a/app/globals.css
+++ b/app/globals.css
@@ -124,6 +124,10 @@
     @apply bg-background text-foreground;
   }
 
+  .skip-link {
+    @apply bg-background text-foreground border-border fixed left-4 top-4 z-[100] -translate-y-16 rounded-md border px-3 py-2 text-sm font-medium shadow-md transition-transform focus:translate-y-0 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2;
+  }
+
   :root {
     --chart-1: oklch(0.646 0.222 41.116);
     --chart-2: oklch(0.6 0.118 184.704);

--- a/app/import/page.tsx
+++ b/app/import/page.tsx
@@ -276,14 +276,16 @@ function ImportPageContent() {
 
 export default function ImportPage() {
   return (
-    <Suspense
-      fallback={
-        <div className="flex w-full flex-col items-center justify-center">
-          <Skeleton className="h-96 w-full max-w-prose" />
-        </div>
-      }
-    >
-      <ImportPageContent />
-    </Suspense>
+    <main id="main-content" tabIndex={-1}>
+      <Suspense
+        fallback={
+          <div className="flex w-full flex-col items-center justify-center">
+            <Skeleton className="h-96 w-full max-w-prose" />
+          </div>
+        }
+      >
+        <ImportPageContent />
+      </Suspense>
+    </main>
   )
 }

--- a/app/invite/[code]/join/page.tsx
+++ b/app/invite/[code]/join/page.tsx
@@ -62,9 +62,11 @@ export default async function InviteJoinPage({
   }
 
   return (
-    <JoinRequestForm
-      gameId={game.id}
-      gameDescription={game.description ?? undefined}
-    />
+    <main id="main-content" tabIndex={-1}>
+      <JoinRequestForm
+        gameId={game.id}
+        gameDescription={game.description ?? undefined}
+      />
+    </main>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${inter.className} min-h-screen bg-background antialiased`}>
+      <body
+        className={`${inter.className} min-h-screen bg-background antialiased`}
+      >
+        <a href="#main-content" className="skip-link">
+          Skip to main content
+        </a>
         <NuqsAdapter>{children}</NuqsAdapter>
         <Toaster richColors expand={false} position="bottom-center" />
         <Analytics />

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -13,8 +13,12 @@ export default async function LoginPage({
 }) {
   const params = await searchParams
   return (
-    <div className="flex min-h-[80vh] flex-col items-center justify-center">
+    <main
+      id="main-content"
+      tabIndex={-1}
+      className="flex min-h-[80vh] flex-col items-center justify-center"
+    >
       <LoginForm next={params.next} />
-    </div>
+    </main>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,13 @@
 import type { Metadata } from "next"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "@/components/ui/card"
 
 export const metadata: Metadata = {
   title: "ChipCount",
@@ -10,13 +16,17 @@ export const metadata: Metadata = {
 
 export default function LandingPage() {
   return (
-    <div className="flex min-h-[80vh] flex-col items-center justify-center">
+    <main
+      id="main-content"
+      tabIndex={-1}
+      className="flex min-h-[80vh] flex-col items-center justify-center"
+    >
       <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle className="text-2xl">ChipCount</CardTitle>
           <CardDescription>
-            Track poker games, calculate payouts, and see who&apos;s up over time.
-            Log in to start or join a game.
+            Track poker games, calculate payouts, and see who&apos;s up over
+            time. Log in to start or join a game.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -27,6 +37,6 @@ export default function LandingPage() {
           </Link>
         </CardContent>
       </Card>
-    </div>
+    </main>
   )
 }

--- a/app/profile/[userId]/page.tsx
+++ b/app/profile/[userId]/page.tsx
@@ -1,7 +1,13 @@
 import { createClient } from "@/lib/supabase/server"
 import { notFound } from "next/navigation"
 import Link from "next/link"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "@/components/ui/card"
 import { formatDollar } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { NetProfitGraph } from "@/components/net-profit-graph"
@@ -16,18 +22,23 @@ export default async function PublicProfilePage({
   const supabase = await createClient()
   const { data: profile } = await supabase
     .from("profiles")
-    .select("id, display_name, phone, email, venmo_handle, net_profit, profile_public")
+    .select(
+      "id, display_name, phone, email, venmo_handle, net_profit, profile_public"
+    )
     .eq("id", userId)
     .single()
 
   if (!profile || !profile.profile_public) notFound()
 
   const net = Number(profile.net_profit)
+  const netLabel = net > 0 ? "profit" : net < 0 ? "loss" : "even"
 
   return (
     <div className="mx-auto max-w-lg space-y-6">
       <Link href="/dashboard">
-        <Button variant="ghost" size="sm">Back to dashboard</Button>
+        <Button variant="ghost" size="sm">
+          Back to dashboard
+        </Button>
       </Link>
       <Card>
         <CardHeader>
@@ -37,8 +48,11 @@ export default async function PublicProfilePage({
         <CardContent className="space-y-4">
           <div className="rounded-lg border bg-muted/50 p-4">
             <p className="text-muted-foreground text-sm">Net profit</p>
-            <p className={`text-2xl font-bold ${net >= 0 ? "text-green-600" : "text-red-600"}`}>
+            <p
+              className={`text-2xl font-bold ${net >= 0 ? "text-green-600" : "text-red-600"}`}
+            >
               {formatDollar(net)}
+              <span className="sr-only"> {netLabel}</span>
             </p>
           </div>
           {profile.venmo_handle && (
@@ -48,8 +62,7 @@ export default async function PublicProfilePage({
               rel="noopener noreferrer"
               className="text-link inline-flex items-center gap-1"
             >
-              <IoLogoVenmo className="h-5 w-5" />
-              @{profile.venmo_handle}
+              <IoLogoVenmo className="h-5 w-5" />@{profile.venmo_handle}
             </a>
           )}
           {profile.phone && <p className="text-sm">Phone: {profile.phone}</p>}

--- a/app/profile/layout.tsx
+++ b/app/profile/layout.tsx
@@ -44,7 +44,9 @@ export default async function ProfileLayout({
           </nav>
         </div>
       </header>
-      <main className="flex-1 p-4">{children}</main>
+      <main id="main-content" tabIndex={-1} className="flex-1 p-4">
+        {children}
+      </main>
     </div>
   )
 }

--- a/components/copy-button.tsx
+++ b/components/copy-button.tsx
@@ -15,7 +15,12 @@ export function CopyButton({ textToCopy }: { textToCopy: string }) {
   }
 
   return (
-    <Button onClick={handleCopy} variant="outline" size="icon">
+    <Button
+      onClick={handleCopy}
+      variant="outline"
+      size="icon"
+      aria-label={copied ? "Copied" : "Copy"}
+    >
       {copied ? (
         <Check className="h-4 w-4 text-green-500" />
       ) : (

--- a/components/dashboard-actions.tsx
+++ b/components/dashboard-actions.tsx
@@ -4,6 +4,14 @@ import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { createClient } from "@/lib/supabase/client"
 import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Loader2, Play, LogIn } from "lucide-react"
@@ -19,23 +27,26 @@ export function DashboardActions() {
   const [gameName, setGameName] = useState("")
   const [showNameInput, setShowNameInput] = useState(false)
 
-  async function ensureProfile(supabase: ReturnType<typeof createClient>, user: User) {
+  async function ensureProfile(
+    supabase: ReturnType<typeof createClient>,
+    user: User
+  ) {
     const fallbackName = user.email ? user.email.split("@")[0] : null
     const displayName =
-      (typeof user.user_metadata?.display_name === "string" && user.user_metadata.display_name) ||
-      (typeof user.user_metadata?.full_name === "string" && user.user_metadata.full_name) ||
+      (typeof user.user_metadata?.display_name === "string" &&
+        user.user_metadata.display_name) ||
+      (typeof user.user_metadata?.full_name === "string" &&
+        user.user_metadata.full_name) ||
       fallbackName
 
-    const { error } = await supabase
-      .from("profiles")
-      .upsert(
-        {
-          id: user.id,
-          email: user.email ?? null,
-          display_name: displayName
-        },
-        { onConflict: "id", ignoreDuplicates: true }
-      )
+    const { error } = await supabase.from("profiles").upsert(
+      {
+        id: user.id,
+        email: user.email ?? null,
+        display_name: displayName
+      },
+      { onConflict: "id", ignoreDuplicates: true }
+    )
 
     if (error) throw error
   }
@@ -46,7 +57,9 @@ export function DashboardActions() {
     setStartLoading(true)
     try {
       const supabase = createClient()
-      const { data: { user } } = await supabase.auth.getUser()
+      const {
+        data: { user }
+      } = await supabase.auth.getUser()
       if (!user) {
         setStartError("Not logged in")
         setStartLoading(false)
@@ -62,11 +75,13 @@ export function DashboardActions() {
         .select("id, short_code")
         .single()
       if (error) throw error
-      const { error: playerError } = await supabase.from("game_players").insert({
-        game_id: game.id,
-        user_id: user.id,
-        status: "approved"
-      })
+      const { error: playerError } = await supabase
+        .from("game_players")
+        .insert({
+          game_id: game.id,
+          user_id: user.id,
+          status: "approved"
+        })
       if (playerError) throw playerError
       router.push(`/game/${game.id}`)
       router.refresh()
@@ -88,7 +103,9 @@ export function DashboardActions() {
     setJoinLoading(true)
     try {
       const supabase = createClient()
-      const { data: { user } } = await supabase.auth.getUser()
+      const {
+        data: { user }
+      } = await supabase.auth.getUser()
       if (!user) {
         setJoinError("Not logged in")
         setJoinLoading(false)
@@ -108,11 +125,13 @@ export function DashboardActions() {
         setJoinLoading(false)
         return
       }
-      const { error: insertError } = await supabase.from("game_players").insert({
-        game_id: game.id,
-        user_id: user.id,
-        status: "pending"
-      })
+      const { error: insertError } = await supabase
+        .from("game_players")
+        .insert({
+          game_id: game.id,
+          user_id: user.id,
+          status: "pending"
+        })
       if (insertError) {
         if (insertError.code === "23505") {
           setJoinError("You already joined this game")
@@ -133,58 +152,73 @@ export function DashboardActions() {
 
   return (
     <div className="flex flex-col gap-6">
-      {/* Start Game modal */}
-      {showNameInput && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center"
-          onClick={(e) => {
-            if (e.target === e.currentTarget) {
-              setShowNameInput(false)
-              setGameName("")
-              setStartError(null)
-            }
-          }}
-        >
-          <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
-          <div className="relative z-10 w-full max-w-sm mx-4 rounded-2xl border bg-background shadow-2xl p-6 space-y-5">
-            <div className="space-y-1">
-              <h2 className="text-lg font-semibold">New Table</h2>
-              <p className="text-zinc-400 text-sm">Give your table a name so players know what they're joining.</p>
+      <Dialog
+        open={showNameInput}
+        onOpenChange={(open) => {
+          if (!open && !startLoading) {
+            setShowNameInput(false)
+            setGameName("")
+            setStartError(null)
+          } else {
+            setShowNameInput(open)
+          }
+        }}
+      >
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>New Table</DialogTitle>
+            <DialogDescription>
+              Give your table a name so players know what they&apos;re joining.
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleStartGame} className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="game-name">
+                Table name{" "}
+                <span className="text-muted-foreground font-normal">
+                  (optional)
+                </span>
+              </Label>
+              <Input
+                id="game-name"
+                placeholder="e.g. Friday Night Poker"
+                value={gameName}
+                onChange={(e) => setGameName(e.target.value)}
+                autoFocus
+                disabled={startLoading}
+                className="bg-muted/50"
+              />
             </div>
-            <form onSubmit={handleStartGame} className="space-y-4">
-              <div className="space-y-1.5">
-                <Label htmlFor="game-name">
-                  Table name <span className="text-muted-foreground font-normal">(optional)</span>
-                </Label>
-                <Input
-                  id="game-name"
-                  placeholder="e.g. Friday Night Poker"
-                  value={gameName}
-                  onChange={(e) => setGameName(e.target.value)}
-                  autoFocus
-                  disabled={startLoading}
-                  className="bg-muted/50"
-                />
-              </div>
-              {startError && <p className="text-destructive text-sm">{startError}</p>}
-              <div className="flex gap-2">
-                <Button type="submit" disabled={startLoading} className="flex-1">
-                  {startLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Play className="mr-2 h-4 w-4" />}
-                  Create Table
-                </Button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  disabled={startLoading}
-                  onClick={() => { setShowNameInput(false); setGameName(""); setStartError(null) }}
-                >
-                  Cancel
-                </Button>
-              </div>
-            </form>
-          </div>
-        </div>
-      )}
+            {startError && (
+              <p className="text-destructive text-sm" role="alert">
+                {startError}
+              </p>
+            )}
+            <DialogFooter>
+              <Button type="submit" disabled={startLoading} className="flex-1">
+                {startLoading ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Play className="mr-2 h-4 w-4" />
+                )}
+                Create Table
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                disabled={startLoading}
+                onClick={() => {
+                  setShowNameInput(false)
+                  setGameName("")
+                  setStartError(null)
+                }}
+              >
+                Cancel
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
 
       {/* Start Game button */}
       <div className="flex flex-col gap-2">
@@ -202,7 +236,6 @@ export function DashboardActions() {
         </p>
       </div>
 
-
       <form onSubmit={handleJoinGame} className="flex flex-col gap-2">
         <Label htmlFor="join-code">Join with Game ID</Label>
         <div className="flex gap-2">
@@ -214,12 +247,20 @@ export function DashboardActions() {
             className="font-mono"
           />
           <Button type="submit" disabled={joinLoading}>
-            {joinLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <LogIn className="h-4 w-4" />}
+            {joinLoading ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <LogIn className="h-4 w-4" />
+            )}
+            <span className="sr-only">Join table</span>
           </Button>
         </div>
-        {joinError && <p className="text-destructive text-sm">{joinError}</p>}
+        {joinError && (
+          <p className="text-destructive text-sm" role="alert">
+            {joinError}
+          </p>
+        )}
       </form>
-
     </div>
   )
 }

--- a/components/donut-chart.tsx
+++ b/components/donut-chart.tsx
@@ -23,7 +23,7 @@ export function DonutCharts({ payout }: { payout: PayoutSchema }) {
     let success: string
     let destructive: string
     let muted: string
-    
+
     if (typeof window === "undefined") {
       // Server-side fallback colors
       success = "#22c55e"
@@ -31,19 +31,21 @@ export function DonutCharts({ payout }: { payout: PayoutSchema }) {
       muted = "#71717a"
     } else {
       // Check for dark mode and use appropriate colors
-      const isDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
-      
+      const isDark =
+        window.matchMedia &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches
+
       if (isDark) {
-        success = "#4ade80"  // green-400
-        destructive = "#f87171"  // red-400
-        muted = "#9ca3af"  // gray-400
+        success = "#4ade80" // green-400
+        destructive = "#f87171" // red-400
+        muted = "#9ca3af" // gray-400
       } else {
-        success = "#22c55e"  // green-500
-        destructive = "#ef4444"  // red-500
-        muted = "#71717a"  // zinc-500
+        success = "#22c55e" // green-500
+        destructive = "#ef4444" // red-500
+        muted = "#71717a" // zinc-500
       }
     }
-    
+
     return chroma
       .scale([success, muted, destructive])
       .mode("lrgb")
@@ -72,7 +74,7 @@ export function DonutCharts({ payout }: { payout: PayoutSchema }) {
       config={chartConfig}
       className="m-auto mx-auto aspect-6/5 h-[250px]"
     >
-      <PieChart>
+      <PieChart accessibilityLayer>
         <ChartTooltip
           cursor={false}
           content={
@@ -98,7 +100,7 @@ export function DonutCharts({ payout }: { payout: PayoutSchema }) {
           outerRadius={100}
           innerRadius={90}
           strokeWidth={2}
-          stroke="hsl(var(--background))"
+          stroke="var(--background)"
           paddingAngle={5}
         >
           <LabelList
@@ -117,7 +119,7 @@ export function DonutCharts({ payout }: { payout: PayoutSchema }) {
           outerRadius={80}
           innerRadius={totalPot < 100 ? 50 : totalPot < 1000 ? 60 : 63.5}
           strokeWidth={2}
-          stroke="hsl(var(--background))"
+          stroke="var(--background)"
           paddingAngle={5}
         >
           {Math.abs(payout.slippage) < 1e-9 && (

--- a/components/game-form.tsx
+++ b/components/game-form.tsx
@@ -103,11 +103,13 @@ const PlayerField = ({
   control,
   name,
   placeholder,
+  label,
   className
 }: {
   control: Control<GameSchema>
   name: `players.${number}.name`
   placeholder: string
+  label: string
   className?: string
 }) => (
   <FormField
@@ -116,7 +118,7 @@ const PlayerField = ({
     render={({ field }) => (
       <FormItem className={className}>
         <FormControl>
-          <Input placeholder={placeholder} {...field} />
+          <Input placeholder={placeholder} aria-label={label} {...field} />
         </FormControl>
         <FormMessage />
       </FormItem>
@@ -127,11 +129,13 @@ const PlayerField = ({
 const NumericPlayerField = ({
   control,
   name,
-  placeholder
+  placeholder,
+  label
 }: {
   control: Control<GameSchema>
   name: `players.${number}.cashIn` | `players.${number}.cashOut`
   placeholder: string
+  label: string
 }) => (
   <FormField
     control={control}
@@ -142,6 +146,7 @@ const NumericPlayerField = ({
           <Input
             type="number"
             placeholder={placeholder}
+            aria-label={label}
             {...field}
             onChange={(e) => field.onChange(e.target.valueAsNumber || 0)}
           />
@@ -176,22 +181,26 @@ const PlayerFields = ({
           control={form.control}
           name={`players.${index}.name`}
           placeholder={`Player ${index + 1}`}
+          label={`Player ${index + 1} name`}
           className="grow"
         />
         <NumericPlayerField
           control={form.control}
           name={`players.${index}.cashIn`}
           placeholder="In"
+          label={`Cash in for player ${index + 1}`}
         />
         <NumericPlayerField
           control={form.control}
           name={`players.${index}.cashOut`}
           placeholder="Out"
+          label={`Cash out for player ${index + 1}`}
         />
         <Button
           type="button"
           variant="destructive"
           size="icon"
+          aria-label={`Remove player ${index + 1}`}
           onClick={() => remove(index)}
           disabled={fields.length <= 2}
         >

--- a/components/game-metrics-client.tsx
+++ b/components/game-metrics-client.tsx
@@ -4,702 +4,922 @@ import { useState, useMemo } from "react"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import {
-    LineChart,
-    Line,
-    XAxis,
-    YAxis,
-    CartesianGrid,
-    Tooltip,
-    ResponsiveContainer,
-    BarChart,
-    Bar,
-    Cell,
-    ReferenceLine
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  Cell,
+  ReferenceLine
 } from "recharts"
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription
+} from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { PayoutStatsView } from "./payout-stats-view"
-import { TrendingUp, TrendingDown, Minus, History, Search, ArrowLeft, X, Trash2, Loader2 } from "lucide-react"
+import {
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  History,
+  Search,
+  ArrowLeft,
+  X,
+  Trash2,
+  Loader2
+} from "lucide-react"
 import { formatDollar, calcPayouts } from "@/lib/utils"
 import type { GameSchema } from "@/lib/schemas"
 import { deleteSessionAt } from "@/lib/actions"
 import {
-    AlertDialog,
-    AlertDialogCancel,
-    AlertDialogContent,
-    AlertDialogDescription,
-    AlertDialogFooter,
-    AlertDialogHeader,
-    AlertDialogTitle,
-    AlertDialogTrigger
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger
 } from "@/components/ui/alert-dialog"
 
 type SessionPlayer = {
-    user_id: string
-    display_name: string | null
-    venmo_handle: string | null
-    game_net: number
-    cash_in: number
-    cash_out: number
-    session_net: number
-    is_me: boolean
-    was_kicked: boolean
+  user_id: string
+  display_name: string | null
+  venmo_handle: string | null
+  game_net: number
+  cash_in: number
+  cash_out: number
+  session_net: number
+  is_me: boolean
+  was_kicked: boolean
 }
 
 type StandingsPlayer = {
-    user_id: string
-    display_name: string | null
-    venmo_handle: string | null
-    game_net: number
-    is_me: boolean
-    was_kicked: boolean
+  user_id: string
+  display_name: string | null
+  venmo_handle: string | null
+  game_net: number
+  is_me: boolean
+  was_kicked: boolean
 }
 
 type SessionChartPoint = { label: string; date: string; net: number }
 
 type SessionHistoryEntry = {
-    snapshotted_at: string
-    label: string
-    players: { name: string; cashIn: number; cashOut: number }[]
+  snapshotted_at: string
+  label: string
+  players: { name: string; cashIn: number; cashOut: number }[]
 }
 
 const TOOLTIP_STYLE = {
-    contentStyle: {
-        backgroundColor: "var(--background)",
-        border: "1px solid var(--border)",
-        borderRadius: "10px",
-        color: "var(--foreground)",
-        fontSize: 13,
-        boxShadow: "0 4px 24px oklch(0 0 0 / 0.25)"
-    },
-    itemStyle: { color: "var(--muted-foreground)" },
-    labelStyle: { color: "var(--foreground)", fontWeight: 600, marginBottom: 2 }
+  contentStyle: {
+    backgroundColor: "var(--background)",
+    border: "1px solid var(--border)",
+    borderRadius: "10px",
+    color: "var(--foreground)",
+    fontSize: 13,
+    boxShadow: "0 4px 24px oklch(0 0 0 / 0.25)"
+  },
+  itemStyle: { color: "var(--muted-foreground)" },
+  labelStyle: { color: "var(--foreground)", fontWeight: 600, marginBottom: 2 }
 }
 
 const TICK = { fontSize: 11, fill: "var(--muted-foreground)" }
 
 function HostDeleteSessionButton({
-    gameId,
-    snapshottedAt,
-    onDeleted
+  gameId,
+  snapshottedAt,
+  onDeleted
 }: {
-    gameId: string
-    snapshottedAt: string
-    onDeleted: () => void
+  gameId: string
+  snapshottedAt: string
+  onDeleted: () => void
 }) {
-    const [open, setOpen] = useState(false)
-    const [pending, setPending] = useState(false)
+  const [open, setOpen] = useState(false)
+  const [pending, setPending] = useState(false)
 
-    async function handleConfirm() {
-        setPending(true)
-        try {
-            await deleteSessionAt(gameId, snapshottedAt)
-            toast.success("Session removed from history")
-            setOpen(false)
-            onDeleted()
-        } catch (e) {
-            toast.error(e instanceof Error ? e.message : "Failed to delete session")
-        } finally {
-            setPending(false)
-        }
+  async function handleConfirm() {
+    setPending(true)
+    try {
+      await deleteSessionAt(gameId, snapshottedAt)
+      toast.success("Session removed from history")
+      setOpen(false)
+      onDeleted()
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to delete session")
+    } finally {
+      setPending(false)
     }
+  }
 
-    return (
-        <AlertDialog
-            open={open}
-            onOpenChange={(next) => {
-                if (!pending) setOpen(next)
-            }}
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!pending) setOpen(next)
+      }}
+    >
+      <AlertDialogTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-9 w-9 shrink-0 text-muted-foreground hover:text-destructive"
+          aria-label="Delete session from history"
         >
-            <AlertDialogTrigger asChild>
-                <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="h-9 w-9 shrink-0 text-muted-foreground hover:text-destructive"
-                    aria-label="Delete session from history"
-                >
-                    <Trash2 className="h-4 w-4" />
-                </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-                <AlertDialogHeader>
-                    <AlertDialogTitle>Delete this session?</AlertDialogTitle>
-                    <AlertDialogDescription>
-                        Removes this session from metrics history and rolls back the all-time net
-                        profit recorded for each player when it was closed. Debts from that close
-                        are unchanged.
-                    </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                    <AlertDialogCancel disabled={pending}>Cancel</AlertDialogCancel>
-                    <Button variant="destructive" disabled={pending} onClick={() => void handleConfirm()}>
-                        {pending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                        {pending ? "Deleting…" : "Delete session"}
-                    </Button>
-                </AlertDialogFooter>
-            </AlertDialogContent>
-        </AlertDialog>
-    )
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete this session?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Removes this session from metrics history and rolls back the
+            all-time net profit recorded for each player when it was closed.
+            Debts from that close are unchanged.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={pending}>Cancel</AlertDialogCancel>
+          <Button
+            variant="destructive"
+            disabled={pending}
+            onClick={() => void handleConfirm()}
+          >
+            {pending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {pending ? "Deleting…" : "Delete session"}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
 }
 
 function yDomain(data: { net: number }[]): [number, number] {
-    if (!data.length) return [-10, 10]
-    const vals = data.map((d) => d.net)
-    const max = Math.max(...vals, 0)
-    const min = Math.min(...vals, 0)
-    const range = max - min || 1
-    const pad = range * 0.2
-    return [Math.floor(min - pad), Math.ceil(max + pad)]
+  if (!data.length) return [-10, 10]
+  const vals = data.map((d) => d.net)
+  const max = Math.max(...vals, 0)
+  const min = Math.min(...vals, 0)
+  const range = max - min || 1
+  const pad = range * 0.2
+  return [Math.floor(min - pad), Math.ceil(max + pad)]
 }
 
 function NetBadge({ value }: { value: number }) {
-    if (value > 0.01)
-        return (
-            <span className="flex items-center gap-1 text-emerald-400 font-semibold tabular-nums">
-                <TrendingUp className="h-3.5 w-3.5" />
-                {formatDollar(value)}
-            </span>
-        )
-    if (value < -0.01)
-        return (
-            <span className="flex items-center gap-1 text-red-400 font-semibold tabular-nums">
-                <TrendingDown className="h-3.5 w-3.5" />
-                {formatDollar(value)}
-            </span>
-        )
+  const status = value > 0.01 ? "profit" : value < -0.01 ? "loss" : "even"
+  if (value > 0.01)
     return (
-        <span className="flex items-center gap-1 text-muted-foreground font-semibold">
-            <Minus className="h-3.5 w-3.5" />
-            $0
-        </span>
+      <span className="flex items-center gap-1 text-emerald-700 font-semibold tabular-nums dark:text-emerald-300">
+        <TrendingUp className="h-3.5 w-3.5" />
+        {formatDollar(value)} <span className="sr-only">{status}</span>
+      </span>
     )
+  if (value < -0.01)
+    return (
+      <span className="flex items-center gap-1 text-red-600 font-semibold tabular-nums dark:text-red-300">
+        <TrendingDown className="h-3.5 w-3.5" />
+        {formatDollar(value)} <span className="sr-only">{status}</span>
+      </span>
+    )
+  return (
+    <span className="flex items-center gap-1 text-muted-foreground font-semibold">
+      <Minus className="h-3.5 w-3.5" />
+      $0 <span className="sr-only">{status}</span>
+    </span>
+  )
+}
+
+function netStatus(value: number) {
+  if (value > 0.01) return "profit"
+  if (value < -0.01) return "loss"
+  return "even"
+}
+
+function ChartSummary({
+  title,
+  items
+}: {
+  title: string
+  items: { name: string; value: number }[]
+}) {
+  if (!items.length) return null
+
+  return (
+    <div className="sr-only">
+      <h3>{title}</h3>
+      <ul>
+        {items.map((item) => (
+          <li key={item.name}>
+            {item.name}: {formatDollar(item.value)} {netStatus(item.value)}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
 }
 
 function PlayerBarChart({
-    data,
-    tooltipLabel
+  data,
+  tooltipLabel
 }: {
-    data: { name: string; net: number; isMe: boolean }[]
-    tooltipLabel: string
+  data: { name: string; net: number; isMe: boolean }[]
+  tooltipLabel: string
 }) {
-    const allZero = data.every((d) => Math.abs(d.net) < 0.01)
-    if (allZero) {
-        return (
-            <p className="text-muted-foreground text-sm text-center py-6">
-                No data yet — this updates when games are ended.
-            </p>
-        )
-    }
-    const domain = yDomain(data)
-    const barWidth = data.length <= 4 ? 48 : data.length <= 8 ? 36 : 24
+  const allZero = data.every((d) => Math.abs(d.net) < 0.01)
+  if (allZero) {
     return (
-        <div className="h-[280px] w-full">
-            <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 4 }} barSize={barWidth} barCategoryGap="20%">
-                    <CartesianGrid vertical={false} stroke="var(--border)" strokeOpacity={0.4} strokeDasharray="3 3" />
-                    <XAxis
-                        dataKey="name"
-                        tick={TICK}
-                        axisLine={false}
-                        tickLine={false}
-                        interval={0}
-                        tickFormatter={(v: string) => (v.length > 12 ? v.slice(0, 11) + "…" : v)}
-                    />
-                    <YAxis
-                        tickFormatter={(v) => formatDollar(v)}
-                        tick={TICK}
-                        width={58}
-                        axisLine={false}
-                        tickLine={false}
-                        domain={domain}
-                    />
-                    <Tooltip
-                        formatter={(value: number) => [formatDollar(value), tooltipLabel]}
-                        cursor={{ fill: "oklch(0.5 0 0 / 0.1)", radius: 6 }}
-                        {...TOOLTIP_STYLE}
-                    />
-                    <ReferenceLine y={0} stroke="var(--muted-foreground)" strokeWidth={1} strokeOpacity={0.5} />
-                    <Bar dataKey="net" radius={[6, 6, 2, 2]}>
-                        {data.map((entry, i) => (
-                            <Cell
-                                key={i}
-                                fill={entry.net >= 0 ? "#22c55e" : "#ef4444"}
-                                opacity={entry.isMe ? 1 : 0.55}
-                            />
-                        ))}
-                    </Bar>
-                </BarChart>
-            </ResponsiveContainer>
-        </div>
+      <p className="text-muted-foreground text-sm text-center py-6">
+        No data yet — this updates when games are ended.
+      </p>
     )
+  }
+  const domain = yDomain(data)
+  const barWidth = data.length <= 4 ? 48 : data.length <= 8 ? 36 : 24
+  return (
+    <div className="h-[280px] w-full">
+      <ChartSummary
+        title={tooltipLabel}
+        items={data.map((d) => ({ name: d.name, value: d.net }))}
+      />
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart
+          accessibilityLayer
+          data={data}
+          margin={{ top: 8, right: 8, left: 0, bottom: 4 }}
+          barSize={barWidth}
+          barCategoryGap="20%"
+        >
+          <CartesianGrid
+            vertical={false}
+            stroke="var(--border)"
+            strokeOpacity={0.4}
+            strokeDasharray="3 3"
+          />
+          <XAxis
+            dataKey="name"
+            tick={TICK}
+            axisLine={false}
+            tickLine={false}
+            interval={0}
+            tickFormatter={(v: string) =>
+              v.length > 12 ? v.slice(0, 11) + "…" : v
+            }
+          />
+          <YAxis
+            tickFormatter={(v) => formatDollar(v)}
+            tick={TICK}
+            width={58}
+            axisLine={false}
+            tickLine={false}
+            domain={domain}
+          />
+          <Tooltip
+            formatter={(value: number) => [formatDollar(value), tooltipLabel]}
+            cursor={{ fill: "oklch(0.5 0 0 / 0.1)", radius: 6 }}
+            {...TOOLTIP_STYLE}
+          />
+          <ReferenceLine
+            y={0}
+            stroke="var(--muted-foreground)"
+            strokeWidth={1}
+            strokeOpacity={0.5}
+          />
+          <Bar dataKey="net" radius={[6, 6, 2, 2]}>
+            {data.map((entry, i) => (
+              <Cell
+                key={i}
+                fill={entry.net >= 0 ? "#22c55e" : "#ef4444"}
+                opacity={entry.isMe ? 1 : 0.55}
+              />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
 }
 
 function SessionHistoryModal({
-    gameId,
-    isHost,
-    sessions,
-    onClose,
-    afterSessionDeleted
+  gameId,
+  isHost,
+  sessions,
+  onClose,
+  afterSessionDeleted
 }: {
-    gameId: string
-    isHost: boolean
-    sessions: SessionHistoryEntry[]
-    onClose: () => void
-    afterSessionDeleted: () => void
+  gameId: string
+  isHost: boolean
+  sessions: SessionHistoryEntry[]
+  onClose: () => void
+  afterSessionDeleted: () => void
 }) {
-    const [search, setSearch] = useState("")
-    const [selectedSession, setSelectedSession] = useState<SessionHistoryEntry | null>(null)
+  const [search, setSearch] = useState("")
+  const [selectedSession, setSelectedSession] =
+    useState<SessionHistoryEntry | null>(null)
 
-    const filtered = useMemo(() => {
-        if (!search.trim()) return sessions
-        const q = search.toLowerCase()
-        return sessions.filter((s) =>
-            s.label.toLowerCase().includes(q) ||
-            s.players.some((p) => p.name.toLowerCase().includes(q))
-        )
-    }, [sessions, search])
-
-    const selectedPayout = useMemo(() => {
-        if (!selectedSession || selectedSession.players.length < 2) return null
-        const gameData: GameSchema = {
-            players: selectedSession.players.map((p) => ({
-                name: p.name,
-                cashIn: p.cashIn,
-                cashOut: p.cashOut,
-            })),
-        }
-        return calcPayouts(gameData)
-    }, [selectedSession])
-
-    return (
-        <div
-            className="fixed inset-0 z-50 flex items-center justify-center p-2 sm:p-4"
-            onClick={(e) => {
-                if (e.target === e.currentTarget) onClose()
-            }}
-        >
-            <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
-
-            <div className="relative z-10 w-full max-w-sm sm:max-w-2xl max-h-[90vh] sm:max-h-[85vh] rounded-2xl border bg-background shadow-2xl flex flex-col overflow-hidden">
-                {/* Header */}
-                <div className="flex items-center justify-between px-4 sm:px-6 pt-4 sm:pt-5 pb-3">
-                    {selectedSession ? (
-                        <div className="flex items-center gap-2 sm:gap-3 min-w-0 flex-1">
-                            <button
-                                onClick={() => setSelectedSession(null)}
-                                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-                            >
-                                <ArrowLeft className="h-4 w-4" />
-                            </button>
-                            <div className="min-w-0 flex-1">
-                                <h2 className="text-base sm:text-lg font-semibold truncate">Session Payouts</h2>
-                                <p className="text-xs sm:text-sm text-muted-foreground truncate">{selectedSession.label}</p>
-                            </div>
-                            {isHost && (
-                                <HostDeleteSessionButton
-                                    gameId={gameId}
-                                    snapshottedAt={selectedSession.snapshotted_at}
-                                    onDeleted={() => {
-                                        setSelectedSession(null)
-                                        afterSessionDeleted()
-                                    }}
-                                />
-                            )}
-                        </div>
-                    ) : (
-                        <div className="flex items-center gap-2">
-                            <History className="h-5 w-5 text-muted-foreground" />
-                            <h2 className="text-base sm:text-lg font-semibold">Session History</h2>
-                        </div>
-                    )}
-                    <button
-                        onClick={onClose}
-                        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground transition-colors ml-2"
-                    >
-                        <X className="h-4 w-4" />
-                    </button>
-                </div>
-
-                {/* Content */}
-                {selectedSession ? (
-                    <div className="flex-1 overflow-y-auto px-4 sm:px-6 pb-4 sm:pb-6">
-                        {selectedPayout ? (
-                            <PayoutStatsView payout={selectedPayout} />
-                        ) : (
-                            <p className="text-muted-foreground text-sm py-8 text-center">
-                                Not enough players to compute payouts.
-                            </p>
-                        )}
-                    </div>
-                ) : (
-                    <>
-                        {/* Search */}
-                        <div className="px-4 sm:px-6 pb-3">
-                            <div className="relative">
-                                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                                <Input
-                                    placeholder="Search sessions..."
-                                    value={search}
-                                    onChange={(e) => setSearch(e.target.value)}
-                                    className="pl-9 bg-muted/50 text-sm"
-                                />
-                            </div>
-                        </div>
-
-                        {/* Session list */}
-                        <div className="flex-1 overflow-y-auto px-4 sm:px-6 pb-4 sm:pb-6">
-                            {filtered.length === 0 ? (
-                                <p className="text-muted-foreground text-sm py-8 text-center px-2">
-                                    {sessions.length === 0
-                                        ? "No sessions recorded yet. Close a session to save history."
-                                        : "No sessions match your search."}
-                                </p>
-                            ) : (
-                                <div className="space-y-3">
-                                    {[...filtered].reverse().map((session) => {
-                                        const totalIn = session.players.reduce((s, p) => s + p.cashIn, 0)
-                                        const totalOut = session.players.reduce((s, p) => s + p.cashOut, 0)
-                                        const pot = totalIn + totalOut
-
-                                        return (
-                                            <div
-                                                key={session.snapshotted_at}
-                                                className="flex gap-1 rounded-xl border bg-muted/30 hover:border-foreground/20 transition-colors overflow-hidden"
-                                            >
-                                                <button
-                                                    type="button"
-                                                    onClick={() => setSelectedSession(session)}
-                                                    className="min-w-0 flex-1 text-left p-3 sm:p-4 hover:bg-muted/60 active:bg-muted/80 transition-colors"
-                                                >
-                                                    <div className="space-y-2">
-                                                        <div className="flex items-center justify-between gap-2">
-                                                            <p className="font-medium text-sm sm:text-base">{session.label}</p>
-                                                            {pot > 0 && (
-                                                                <p className="text-xs sm:text-sm text-emerald-400 font-medium shrink-0">
-                                                                    {formatDollar(pot)}
-                                                                </p>
-                                                            )}
-                                                        </div>
-                                                        <div className="flex items-center justify-between gap-2">
-                                                            <p className="text-xs text-muted-foreground">
-                                                                {session.players.length} player{session.players.length !== 1 ? "s" : ""}
-                                                            </p>
-                                                            <div className="flex flex-wrap gap-1 justify-end max-w-[60%] sm:max-w-[70%]">
-                                                                {session.players.slice(0, 3).map((p) => (
-                                                                    <span
-                                                                        key={p.name}
-                                                                        className="text-xs text-muted-foreground bg-muted rounded px-1.5 py-0.5 truncate max-w-[60px] sm:max-w-[80px]"
-                                                                        title={p.name}
-                                                                    >
-                                                                        {p.name}
-                                                                    </span>
-                                                                ))}
-                                                                {session.players.length > 3 && (
-                                                                    <span className="text-xs text-muted-foreground/60">
-                                                                        +{session.players.length - 3}
-                                                                    </span>
-                                                                )}
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </button>
-                                                {isHost && (
-                                                    <div className="flex items-center border-l border-border/60 pr-1">
-                                                        <HostDeleteSessionButton
-                                                            gameId={gameId}
-                                                            snapshottedAt={session.snapshotted_at}
-                                                            onDeleted={() => {
-                                                                setSelectedSession((s) =>
-                                                                    s?.snapshotted_at === session.snapshotted_at ? null : s
-                                                                )
-                                                                afterSessionDeleted()
-                                                            }}
-                                                        />
-                                                    </div>
-                                                )}
-                                            </div>
-                                        )
-                                    })}
-                                </div>
-                            )}
-                        </div>
-                    </>
-                )}
-            </div>
-        </div>
+  const filtered = useMemo(() => {
+    if (!search.trim()) return sessions
+    const q = search.toLowerCase()
+    return sessions.filter(
+      (s) =>
+        s.label.toLowerCase().includes(q) ||
+        s.players.some((p) => p.name.toLowerCase().includes(q))
     )
+  }, [sessions, search])
+
+  const selectedPayout = useMemo(() => {
+    if (!selectedSession || selectedSession.players.length < 2) return null
+    const gameData: GameSchema = {
+      players: selectedSession.players.map((p) => ({
+        name: p.name,
+        cashIn: p.cashIn,
+        cashOut: p.cashOut
+      }))
+    }
+    return calcPayouts(gameData)
+  }, [selectedSession])
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+    >
+      <DialogContent
+        showCloseButton={false}
+        className="flex max-h-[90vh] max-w-sm flex-col gap-0 overflow-hidden p-0 sm:max-h-[85vh] sm:max-w-2xl"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 sm:px-6 pt-4 sm:pt-5 pb-3">
+          {selectedSession ? (
+            <div className="flex items-center gap-2 sm:gap-3 min-w-0 flex-1">
+              <button
+                type="button"
+                aria-label="Back to session history"
+                onClick={() => setSelectedSession(null)}
+                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                <ArrowLeft className="h-4 w-4" />
+              </button>
+              <div className="min-w-0 flex-1">
+                <DialogTitle className="truncate text-base sm:text-lg">
+                  Session Payouts
+                </DialogTitle>
+                <DialogDescription className="truncate text-xs sm:text-sm">
+                  {selectedSession.label}
+                </DialogDescription>
+              </div>
+              {isHost && (
+                <HostDeleteSessionButton
+                  gameId={gameId}
+                  snapshottedAt={selectedSession.snapshotted_at}
+                  onDeleted={() => {
+                    setSelectedSession(null)
+                    afterSessionDeleted()
+                  }}
+                />
+              )}
+            </div>
+          ) : (
+            <DialogHeader className="flex-row items-center gap-2 space-y-0 text-left">
+              <History className="h-5 w-5 text-muted-foreground" />
+              <DialogTitle className="text-base sm:text-lg">
+                Session History
+              </DialogTitle>
+              <DialogDescription className="sr-only">
+                Search and review recorded sessions for this table.
+              </DialogDescription>
+            </DialogHeader>
+          )}
+          <button
+            type="button"
+            aria-label="Close session history"
+            onClick={onClose}
+            className="ml-2 flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Content */}
+        {selectedSession ? (
+          <div className="flex-1 overflow-y-auto px-4 sm:px-6 pb-4 sm:pb-6">
+            {selectedPayout ? (
+              <PayoutStatsView payout={selectedPayout} />
+            ) : (
+              <p className="text-muted-foreground text-sm py-8 text-center">
+                Not enough players to compute payouts.
+              </p>
+            )}
+          </div>
+        ) : (
+          <>
+            {/* Search */}
+            <div className="px-4 sm:px-6 pb-3">
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <Input
+                  placeholder="Search sessions..."
+                  aria-label="Search sessions"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  className="pl-9 bg-muted/50 text-sm"
+                />
+              </div>
+            </div>
+
+            {/* Session list */}
+            <div className="flex-1 overflow-y-auto px-4 sm:px-6 pb-4 sm:pb-6">
+              {filtered.length === 0 ? (
+                <p className="text-muted-foreground text-sm py-8 text-center px-2">
+                  {sessions.length === 0
+                    ? "No sessions recorded yet. Close a session to save history."
+                    : "No sessions match your search."}
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  {[...filtered].reverse().map((session) => {
+                    const totalIn = session.players.reduce(
+                      (s, p) => s + p.cashIn,
+                      0
+                    )
+                    const totalOut = session.players.reduce(
+                      (s, p) => s + p.cashOut,
+                      0
+                    )
+                    const pot = totalIn + totalOut
+
+                    return (
+                      <div
+                        key={session.snapshotted_at}
+                        className="flex gap-1 rounded-xl border bg-muted/30 hover:border-foreground/20 transition-colors overflow-hidden"
+                      >
+                        <button
+                          type="button"
+                          aria-label={`View payouts for ${session.label}`}
+                          onClick={() => setSelectedSession(session)}
+                          className="min-w-0 flex-1 text-left p-3 sm:p-4 hover:bg-muted/60 active:bg-muted/80 transition-colors"
+                        >
+                          <div className="space-y-2">
+                            <div className="flex items-center justify-between gap-2">
+                              <p className="font-medium text-sm sm:text-base">
+                                {session.label}
+                              </p>
+                              {pot > 0 && (
+                                <p className="text-xs sm:text-sm text-emerald-700 font-medium shrink-0 dark:text-emerald-300">
+                                  {formatDollar(pot)}
+                                </p>
+                              )}
+                            </div>
+                            <div className="flex items-center justify-between gap-2">
+                              <p className="text-xs text-muted-foreground">
+                                {session.players.length} player
+                                {session.players.length !== 1 ? "s" : ""}
+                              </p>
+                              <div className="flex flex-wrap gap-1 justify-end max-w-[60%] sm:max-w-[70%]">
+                                {session.players.slice(0, 3).map((p) => (
+                                  <span
+                                    key={p.name}
+                                    className="text-xs text-muted-foreground bg-muted rounded px-1.5 py-0.5 truncate max-w-[60px] sm:max-w-[80px]"
+                                    title={p.name}
+                                  >
+                                    {p.name}
+                                  </span>
+                                ))}
+                                {session.players.length > 3 && (
+                                  <span className="text-xs text-muted-foreground/60">
+                                    +{session.players.length - 3}
+                                  </span>
+                                )}
+                              </div>
+                            </div>
+                          </div>
+                        </button>
+                        {isHost && (
+                          <div className="flex items-center border-l border-border/60 pr-1">
+                            <HostDeleteSessionButton
+                              gameId={gameId}
+                              snapshottedAt={session.snapshotted_at}
+                              onDeleted={() => {
+                                setSelectedSession((s) =>
+                                  s?.snapshotted_at === session.snapshotted_at
+                                    ? null
+                                    : s
+                                )
+                                afterSessionDeleted()
+                              }}
+                            />
+                          </div>
+                        )}
+                      </div>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
 }
 
 export function GameMetricsClient({
-    gameId,
-    isHost,
-    sessionPlayers,
-    standingsPlayers,
-    sessionChartPoints,
-    cumulativeChartPoints,
-    sessionHistory,
-    currentUserId
+  gameId,
+  isHost,
+  sessionPlayers,
+  standingsPlayers,
+  sessionChartPoints,
+  cumulativeChartPoints,
+  sessionHistory,
+  currentUserId
 }: {
-    gameId: string
-    isHost: boolean
-    sessionPlayers: SessionPlayer[]
-    standingsPlayers: StandingsPlayer[]
-    sessionChartPoints: SessionChartPoint[]
-    cumulativeChartPoints: SessionChartPoint[]
-    sessionHistory: SessionHistoryEntry[]
-    currentUserId: string
+  gameId: string
+  isHost: boolean
+  sessionPlayers: SessionPlayer[]
+  standingsPlayers: StandingsPlayer[]
+  sessionChartPoints: SessionChartPoint[]
+  cumulativeChartPoints: SessionChartPoint[]
+  sessionHistory: SessionHistoryEntry[]
+  currentUserId: string
 }) {
-    const router = useRouter()
-    const [historyOpen, setHistoryOpen] = useState(false)
-    const me = sessionPlayers.find((p) => p.user_id === currentUserId)
+  const router = useRouter()
+  const [historyOpen, setHistoryOpen] = useState(false)
+  const me = sessionPlayers.find((p) => p.user_id === currentUserId)
 
-    const sessionBarData = sessionPlayers.map((p) => ({
-        name: p.display_name || p.venmo_handle || p.user_id.slice(0, 8),
-        net: p.session_net,
-        isMe: p.user_id === currentUserId
-    }))
+  const sessionBarData = sessionPlayers.map((p) => ({
+    name: p.display_name || p.venmo_handle || p.user_id.slice(0, 8),
+    net: p.session_net,
+    isMe: p.user_id === currentUserId
+  }))
 
-    const allTimeBarData = standingsPlayers.map((p) => ({
-        name: p.display_name || p.venmo_handle || p.user_id.slice(0, 8),
-        net: p.game_net,
-        isMe: p.user_id === currentUserId
-    }))
+  const allTimeBarData = standingsPlayers.map((p) => ({
+    name: p.display_name || p.venmo_handle || p.user_id.slice(0, 8),
+    net: p.game_net,
+    isMe: p.user_id === currentUserId
+  }))
 
-    const sessionDomain = yDomain(sessionChartPoints)
-    const cumDomain = yDomain(cumulativeChartPoints)
+  const sessionDomain = yDomain(sessionChartPoints)
+  const cumDomain = yDomain(cumulativeChartPoints)
 
-    const finalCumNet = cumulativeChartPoints[cumulativeChartPoints.length - 1]?.net ?? 0
-    const lineColor = finalCumNet >= 0 ? "#22c55e" : "#ef4444"
+  const finalCumNet =
+    cumulativeChartPoints[cumulativeChartPoints.length - 1]?.net ?? 0
+  const lineColor = finalCumNet >= 0 ? "#22c55e" : "#ef4444"
 
-    return (
-        <div className="space-y-5">
-            {/* Session History button */}
-            <div className="flex justify-end">
-                <Button 
-                    variant="outline" 
-                    size="sm" 
-                    onClick={() => setHistoryOpen(true)}
-                    className="min-h-[44px] px-4"
+  return (
+    <div className="space-y-5">
+      {/* Session History button */}
+      <div className="flex justify-end">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setHistoryOpen(true)}
+          className="min-h-[44px] px-4"
+        >
+          <History className="mr-1.5 h-4 w-4" />
+          <span className="hidden sm:inline">Session History</span>
+          <span className="sm:hidden">History</span>
+        </Button>
+      </div>
+
+      {/* Stat cards */}
+      {me && (
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {[
+            { label: "Session In", value: me.cash_in, neutral: true },
+            { label: "Session Out", value: me.cash_out, neutral: true },
+            { label: "Session Net", value: me.session_net },
+            { label: "Game Net", value: me.game_net }
+          ].map(({ label, value, neutral }) => (
+            <Card
+              key={label}
+              className="bg-card/50 border-border/50 hover:bg-card/80 transition-colors"
+            >
+              <CardContent className="px-4 pt-4 pb-3">
+                <p className="text-xs text-muted-foreground font-medium mb-2">
+                  {label}
+                </p>
+                <p
+                  className={`text-xl font-bold tabular-nums ${
+                    neutral
+                      ? "text-foreground"
+                      : value > 0.01
+                        ? "text-green-500 dark:text-green-400"
+                        : value < -0.01
+                          ? "text-red-500 dark:text-red-400"
+                          : "text-muted-foreground"
+                  }`}
                 >
-                    <History className="mr-1.5 h-4 w-4" />
-                    <span className="hidden sm:inline">Session History</span>
-                    <span className="sm:hidden">History</span>
-                </Button>
-            </div>
-
-            {/* Stat cards */}
-            {me && (
-                <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-                    {[
-                        { label: "Session In", value: me.cash_in, neutral: true },
-                        { label: "Session Out", value: me.cash_out, neutral: true },
-                        { label: "Session Net", value: me.session_net },
-                        { label: "Game Net", value: me.game_net }
-                    ].map(({ label, value, neutral }) => (
-                        <Card key={label} className="bg-card/50 border-border/50 hover:bg-card/80 transition-colors">
-                            <CardContent className="px-4 pt-4 pb-3">
-                                <p className="text-xs text-muted-foreground font-medium mb-2">{label}</p>
-                                <p className={`text-xl font-bold tabular-nums ${neutral ? "text-foreground"
-                                    : value > 0.01 ? "text-green-500 dark:text-green-400"
-                                        : value < -0.01 ? "text-red-500 dark:text-red-400"
-                                            : "text-muted-foreground"
-                                    }`}>
-                                    {formatDollar(value)}
-                                </p>
-                            </CardContent>
-                        </Card>
-                    ))}
-                </div>
-            )}
-
-            {/* Current session */}
-            <Card className="bg-card/50 border-border/50">
-                <CardHeader className="pb-3">
-                    <CardTitle className="text-base">Current Session</CardTitle>
-                    <CardDescription>Live net profit / loss per player</CardDescription>
-                </CardHeader>
-                <CardContent>
-                    {sessionBarData.length === 0 ? (
-                        <p className="text-muted-foreground text-sm py-8 text-center">No approved players yet.</p>
-                    ) : (
-                        <PlayerBarChart data={sessionBarData} tooltipLabel="Session Net" />
-                    )}
-                </CardContent>
+                  {formatDollar(value)}
+                  {!neutral && (
+                    <span className="sr-only"> {netStatus(value)}</span>
+                  )}
+                </p>
+              </CardContent>
             </Card>
-
-            {/* Per-session profit bars */}
-            <Card className="bg-card/50 border-border/50">
-                <CardHeader className="pb-3">
-                    <CardTitle className="text-base">Your Profit Per Session</CardTitle>
-                    <CardDescription>Net profit recorded each time the host closes the session</CardDescription>
-                </CardHeader>
-                <CardContent>
-                    {sessionChartPoints.length === 0 ? (
-                        <p className="text-muted-foreground text-sm py-8 text-center">
-                            Close the session to record the first data point.
-                        </p>
-                    ) : (
-                        <div className="h-[280px] w-full">
-                            <ResponsiveContainer width="100%" height="100%">
-                                <BarChart
-                                    data={sessionChartPoints}
-                                    margin={{ top: 8, right: 8, left: 0, bottom: 4 }}
-                                    barSize={sessionChartPoints.length <= 3 ? 48 : sessionChartPoints.length <= 8 ? 36 : 24}
-                                    barCategoryGap="20%"
-                                >
-                                    <CartesianGrid vertical={false} stroke="var(--border)" strokeOpacity={0.4} strokeDasharray="3 3" />
-                                    <XAxis dataKey="label" tick={TICK} axisLine={false} tickLine={false} />
-                                    <YAxis
-                                        tickFormatter={(v) => formatDollar(v)}
-                                        tick={TICK}
-                                        width={58}
-                                        axisLine={false}
-                                        tickLine={false}
-                                        domain={sessionDomain}
-                                    />
-                                    <Tooltip
-                                        formatter={(value: number) => [formatDollar(value), "Session Net"]}
-                                        labelFormatter={(label, payload) => {
-                                            const pt = payload?.[0]?.payload as SessionChartPoint | undefined
-                                            return pt ? pt.date : label
-                                        }}
-                                        cursor={{ fill: "oklch(0.5 0 0 / 0.1)", radius: 6 }}
-                                        {...TOOLTIP_STYLE}
-                                    />
-                                    <ReferenceLine y={0} stroke="var(--muted-foreground)" strokeWidth={1} strokeOpacity={0.5} />
-                                    <Bar dataKey="net" radius={[6, 6, 2, 2]}>
-                                        {sessionChartPoints.map((entry, i) => (
-                                            <Cell key={i} fill={entry.net >= 0 ? "#22c55e" : "#ef4444"} />
-                                        ))}
-                                    </Bar>
-                                </BarChart>
-                            </ResponsiveContainer>
-                        </div>
-                    )}
-                </CardContent>
-            </Card>
-
-            {/* Cumulative line */}
-            <Card className="bg-card/50 border-border/50">
-                <CardHeader className="pb-3">
-                    <CardTitle className="text-base">Cumulative Profit — This Game</CardTitle>
-                    <CardDescription>Running total across all closed sessions</CardDescription>
-                </CardHeader>
-                <CardContent>
-                    {cumulativeChartPoints.length === 0 ? (
-                        <p className="text-muted-foreground text-sm py-8 text-center">
-                            Close the session to record the first data point.
-                        </p>
-                    ) : (
-                        <div className="h-[280px] w-full">
-                            <ResponsiveContainer width="100%" height="100%">
-                                <LineChart data={cumulativeChartPoints} margin={{ top: 8, right: 20, left: 0, bottom: 4 }}>
-                                    <CartesianGrid vertical={false} stroke="var(--border)" strokeOpacity={0.4} strokeDasharray="3 3" />
-                                    <XAxis dataKey="label" tick={TICK} axisLine={false} tickLine={false} />
-                                    <YAxis
-                                        tickFormatter={(v) => formatDollar(v)}
-                                        tick={TICK}
-                                        width={58}
-                                        axisLine={false}
-                                        tickLine={false}
-                                        domain={cumDomain}
-                                    />
-                                    <Tooltip
-                                        formatter={(value: number) => [formatDollar(value), "Cumulative Net"]}
-                                        labelFormatter={(label, payload) => {
-                                            const pt = payload?.[0]?.payload as SessionChartPoint | undefined
-                                            return pt ? pt.date : label
-                                        }}
-                                        cursor={{ stroke: "var(--muted-foreground)", strokeWidth: 1.5 }}
-                                        {...TOOLTIP_STYLE}
-                                    />
-                                    <ReferenceLine y={0} stroke="var(--muted-foreground)" strokeWidth={1} strokeOpacity={0.5} />
-                                    <Line
-                                        type="monotone"
-                                        dataKey="net"
-                                        stroke={lineColor}
-                                        strokeWidth={2.5}
-                                        dot={(props) => {
-                                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                            const { cx, cy, payload } = props as any
-                                            const c = (payload.net ?? 0) >= 0 ? "#22c55e" : "#ef4444"
-                                            return (
-                                                <circle
-                                                    key={payload.label}
-                                                    cx={cx}
-                                                    cy={cy}
-                                                    r={6}
-                                                    fill={c}
-                                                    stroke="var(--background)"
-                                                    strokeWidth={2}
-                                                />
-                                            )
-                                        }}
-                                        activeDot={{ r: 8, fill: lineColor, stroke: "var(--background)", strokeWidth: 2 }}
-                                    />
-                                </LineChart>
-                            </ResponsiveContainer>
-                        </div>
-                    )}
-                </CardContent>
-            </Card>
-
-            {/* All-time standings */}
-            <Card className="bg-card/50 border-border/50">
-                <CardHeader className="pb-3">
-                    <CardTitle className="text-base">All-Time Standings</CardTitle>
-                    <CardDescription>Lifetime net profit for players at this table</CardDescription>
-                </CardHeader>
-                <CardContent>
-                    {standingsPlayers.length === 0 ? (
-                        <p className="text-muted-foreground text-sm text-center py-8">No data yet.</p>
-                    ) : (
-                        <>
-                            <PlayerBarChart data={allTimeBarData} tooltipLabel="Game Net" />
-                            <div className="space-y-1.5 mt-4">
-                                {[...standingsPlayers]
-                                    .sort((a, b) => b.game_net - a.game_net)
-                                    .map((p, i) => (
-                                        <div
-                                            key={p.user_id}
-                                            className={`flex items-center justify-between rounded-lg px-3 py-2.5 text-sm transition-colors ${p.user_id === currentUserId
-                                                ? "bg-emerald-500/10 border border-emerald-500/30"
-                                                : "bg-muted/40"
-                                                } ${p.was_kicked ? "opacity-60" : ""}`}
-                                        >
-                                            <span className="flex items-center gap-2.5 min-w-0">
-                                                <span className="text-muted-foreground text-xs w-5 tabular-nums shrink-0">#{i + 1}</span>
-                                                <span className="font-medium truncate">
-                                                    {p.display_name || p.venmo_handle || p.user_id.slice(0, 8)}
-                                                    {p.user_id === currentUserId && (
-                                                        <span className="ml-2 text-xs text-emerald-500 font-normal">you</span>
-                                                    )}
-                                                    {p.was_kicked && (
-                                                        <span className="ml-2 text-xs text-muted-foreground font-normal">removed</span>
-                                                    )}
-                                                </span>
-                                            </span>
-                                            <NetBadge value={p.game_net} />
-                                        </div>
-                                    ))}
-                            </div>
-                        </>
-                    )}
-                </CardContent>
-            </Card>
-
-            {/* Session History Modal */}
-            {historyOpen && (
-                <SessionHistoryModal
-                    gameId={gameId}
-                    isHost={isHost}
-                    sessions={sessionHistory}
-                    onClose={() => setHistoryOpen(false)}
-                    afterSessionDeleted={() => router.refresh()}
-                />
-            )}
+          ))}
         </div>
-    )
+      )}
+
+      {/* Current session */}
+      <Card className="bg-card/50 border-border/50">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Current Session</CardTitle>
+          <CardDescription>Live net profit / loss per player</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {sessionBarData.length === 0 ? (
+            <p className="text-muted-foreground text-sm py-8 text-center">
+              No approved players yet.
+            </p>
+          ) : (
+            <PlayerBarChart data={sessionBarData} tooltipLabel="Session Net" />
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Per-session profit bars */}
+      <Card className="bg-card/50 border-border/50">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Your Profit Per Session</CardTitle>
+          <CardDescription>
+            Net profit recorded each time the host closes the session
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {sessionChartPoints.length === 0 ? (
+            <p className="text-muted-foreground text-sm py-8 text-center">
+              Close the session to record the first data point.
+            </p>
+          ) : (
+            <div className="h-[280px] w-full">
+              <ChartSummary
+                title="Your profit per session"
+                items={sessionChartPoints.map((point) => ({
+                  name: point.date,
+                  value: point.net
+                }))}
+              />
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart
+                  accessibilityLayer
+                  data={sessionChartPoints}
+                  margin={{ top: 8, right: 8, left: 0, bottom: 4 }}
+                  barSize={
+                    sessionChartPoints.length <= 3
+                      ? 48
+                      : sessionChartPoints.length <= 8
+                        ? 36
+                        : 24
+                  }
+                  barCategoryGap="20%"
+                >
+                  <CartesianGrid
+                    vertical={false}
+                    stroke="var(--border)"
+                    strokeOpacity={0.4}
+                    strokeDasharray="3 3"
+                  />
+                  <XAxis
+                    dataKey="label"
+                    tick={TICK}
+                    axisLine={false}
+                    tickLine={false}
+                  />
+                  <YAxis
+                    tickFormatter={(v) => formatDollar(v)}
+                    tick={TICK}
+                    width={58}
+                    axisLine={false}
+                    tickLine={false}
+                    domain={sessionDomain}
+                  />
+                  <Tooltip
+                    formatter={(value: number) => [
+                      formatDollar(value),
+                      "Session Net"
+                    ]}
+                    labelFormatter={(label, payload) => {
+                      const pt = payload?.[0]?.payload as
+                        | SessionChartPoint
+                        | undefined
+                      return pt ? pt.date : label
+                    }}
+                    cursor={{ fill: "oklch(0.5 0 0 / 0.1)", radius: 6 }}
+                    {...TOOLTIP_STYLE}
+                  />
+                  <ReferenceLine
+                    y={0}
+                    stroke="var(--muted-foreground)"
+                    strokeWidth={1}
+                    strokeOpacity={0.5}
+                  />
+                  <Bar dataKey="net" radius={[6, 6, 2, 2]}>
+                    {sessionChartPoints.map((entry, i) => (
+                      <Cell
+                        key={i}
+                        fill={entry.net >= 0 ? "#22c55e" : "#ef4444"}
+                      />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Cumulative line */}
+      <Card className="bg-card/50 border-border/50">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">
+            Cumulative Profit — This Game
+          </CardTitle>
+          <CardDescription>
+            Running total across all closed sessions
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {cumulativeChartPoints.length === 0 ? (
+            <p className="text-muted-foreground text-sm py-8 text-center">
+              Close the session to record the first data point.
+            </p>
+          ) : (
+            <div className="h-[280px] w-full">
+              <ChartSummary
+                title="Cumulative profit this game"
+                items={cumulativeChartPoints.map((point) => ({
+                  name: point.date,
+                  value: point.net
+                }))}
+              />
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart
+                  accessibilityLayer
+                  data={cumulativeChartPoints}
+                  margin={{ top: 8, right: 20, left: 0, bottom: 4 }}
+                >
+                  <CartesianGrid
+                    vertical={false}
+                    stroke="var(--border)"
+                    strokeOpacity={0.4}
+                    strokeDasharray="3 3"
+                  />
+                  <XAxis
+                    dataKey="label"
+                    tick={TICK}
+                    axisLine={false}
+                    tickLine={false}
+                  />
+                  <YAxis
+                    tickFormatter={(v) => formatDollar(v)}
+                    tick={TICK}
+                    width={58}
+                    axisLine={false}
+                    tickLine={false}
+                    domain={cumDomain}
+                  />
+                  <Tooltip
+                    formatter={(value: number) => [
+                      formatDollar(value),
+                      "Cumulative Net"
+                    ]}
+                    labelFormatter={(label, payload) => {
+                      const pt = payload?.[0]?.payload as
+                        | SessionChartPoint
+                        | undefined
+                      return pt ? pt.date : label
+                    }}
+                    cursor={{
+                      stroke: "var(--muted-foreground)",
+                      strokeWidth: 1.5
+                    }}
+                    {...TOOLTIP_STYLE}
+                  />
+                  <ReferenceLine
+                    y={0}
+                    stroke="var(--muted-foreground)"
+                    strokeWidth={1}
+                    strokeOpacity={0.5}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="net"
+                    stroke={lineColor}
+                    strokeWidth={2.5}
+                    dot={(props) => {
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      const { cx, cy, payload } = props as any
+                      const c = (payload.net ?? 0) >= 0 ? "#22c55e" : "#ef4444"
+                      return (
+                        <circle
+                          key={payload.label}
+                          cx={cx}
+                          cy={cy}
+                          r={6}
+                          fill={c}
+                          stroke="var(--background)"
+                          strokeWidth={2}
+                        />
+                      )
+                    }}
+                    activeDot={{
+                      r: 8,
+                      fill: lineColor,
+                      stroke: "var(--background)",
+                      strokeWidth: 2
+                    }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* All-time standings */}
+      <Card className="bg-card/50 border-border/50">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">All-Time Standings</CardTitle>
+          <CardDescription>
+            Lifetime net profit for players at this table
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {standingsPlayers.length === 0 ? (
+            <p className="text-muted-foreground text-sm text-center py-8">
+              No data yet.
+            </p>
+          ) : (
+            <>
+              <PlayerBarChart data={allTimeBarData} tooltipLabel="Game Net" />
+              <div className="space-y-1.5 mt-4">
+                {[...standingsPlayers]
+                  .sort((a, b) => b.game_net - a.game_net)
+                  .map((p, i) => (
+                    <div
+                      key={p.user_id}
+                      className={`flex items-center justify-between rounded-lg px-3 py-2.5 text-sm transition-colors ${
+                        p.user_id === currentUserId
+                          ? "bg-emerald-500/10 border border-emerald-500/30"
+                          : "bg-muted/40"
+                      } ${p.was_kicked ? "opacity-60" : ""}`}
+                    >
+                      <span className="flex items-center gap-2.5 min-w-0">
+                        <span className="text-muted-foreground text-xs w-5 tabular-nums shrink-0">
+                          #{i + 1}
+                        </span>
+                        <span className="font-medium truncate">
+                          {p.display_name ||
+                            p.venmo_handle ||
+                            p.user_id.slice(0, 8)}
+                          {p.user_id === currentUserId && (
+                            <span className="ml-2 text-xs text-emerald-500 font-normal">
+                              you
+                            </span>
+                          )}
+                          {p.was_kicked && (
+                            <span className="ml-2 text-xs text-muted-foreground font-normal">
+                              removed
+                            </span>
+                          )}
+                        </span>
+                      </span>
+                      <NetBadge value={p.game_net} />
+                    </div>
+                  ))}
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Session History Modal */}
+      {historyOpen && (
+        <SessionHistoryModal
+          gameId={gameId}
+          isHost={isHost}
+          sessions={sessionHistory}
+          onClose={() => setHistoryOpen(false)}
+          afterSessionDeleted={() => router.refresh()}
+        />
+      )}
+    </div>
+  )
 }

--- a/components/game-session.tsx
+++ b/components/game-session.tsx
@@ -3,14 +3,42 @@
 import { useState, useMemo, useEffect, useRef } from "react"
 import { useRouter } from "next/navigation"
 import { createClient } from "@/lib/supabase/client"
-import { setGameStatus, kickPlayer, requestRejoin, transferHost, updateRequestedAmounts } from "@/lib/actions"
+import {
+  setGameStatus,
+  kickPlayer,
+  requestRejoin,
+  transferHost,
+  updateRequestedAmounts
+} from "@/lib/actions"
 import { calcPayouts } from "@/lib/utils"
 import type { GameSchema } from "@/lib/schemas"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { PayoutStatsView } from "./payout-stats-view"
-import { Loader2, Check, X, Copy, Lock, LockOpen, Crown, ArrowRightLeft } from "lucide-react"
+import {
+  Loader2,
+  Check,
+  X,
+  Copy,
+  Lock,
+  LockOpen,
+  Crown,
+  ArrowRightLeft
+} from "lucide-react"
 import { toast } from "sonner"
 
 type Game = {
@@ -71,15 +99,20 @@ export function GameSession({
   const [selectedPlayer, setSelectedPlayer] = useState<PlayerRow | null>(null)
   const [transferring, setTransferring] = useState(false)
   const [transferConfirm, setTransferConfirm] = useState(false)
-  
+  const [copyFeedback, setCopyFeedback] = useState("")
+
   // Guest functionality — persisted to game_guests table
   const [guests, setGuests] = useState<GuestPlayer[]>([])
-  const [guestForm, setGuestForm] = useState({ name: "", cash_in: "", cash_out: "" })
+  const [guestForm, setGuestForm] = useState({
+    name: "",
+    cash_in: "",
+    cash_out: ""
+  })
   const [lastGameStatus, setLastGameStatus] = useState(game.status)
-  
+
   // Track fields currently being edited to prevent overwrites (ref so fetchAll always sees current value)
   const editingFieldsRef = useRef<Set<string>>(new Set())
-  
+
   const setFieldEditing = (fieldKey: string, editing: boolean) => {
     if (editing) {
       editingFieldsRef.current.add(fieldKey)
@@ -93,7 +126,12 @@ export function GameSession({
 
   // Auto-delete guests when session is reopened (closed -> active)
   useEffect(() => {
-    if (lastGameStatus === "closed" && gameStatus === "active" && isHost && guests.length > 0) {
+    if (
+      lastGameStatus === "closed" &&
+      gameStatus === "active" &&
+      isHost &&
+      guests.length > 0
+    ) {
       // Delete all guests from database
       const deleteGuests = async () => {
         const supabase = createClient()
@@ -121,7 +159,10 @@ export function GameSession({
   const isClosed = gameStatus === "closed"
   const approved = players.filter((p) => p.status === "approved")
   const pending = players.filter((p) => p.status === "pending")
-  
+
+  const playerName = (p: PlayerRow) =>
+    p.display_name || p.venmo_handle || `Player ${p.user_id.slice(0, 8)}`
+
   // Guest management — persisted to Supabase
   async function addGuest(name: string) {
     if (!name.trim()) return
@@ -134,7 +175,7 @@ export function GameSession({
         game_id: game.id,
         name: name.trim(),
         cash_in: cashIn ?? 0,
-        cash_out: cashOut ?? 0,
+        cash_out: cashOut ?? 0
       })
       .select("id, name, cash_in, cash_out")
       .single()
@@ -142,7 +183,15 @@ export function GameSession({
       toast.error("Failed to add guest")
       return
     }
-    setGuests((prev) => [...prev, { id: data.id, name: data.name, cash_in: data.cash_in, cash_out: data.cash_out }])
+    setGuests((prev) => [
+      ...prev,
+      {
+        id: data.id,
+        name: data.name,
+        cash_in: data.cash_in,
+        cash_out: data.cash_out
+      }
+    ])
     setGuestForm({ name: "", cash_in: "", cash_out: "" })
     toast.success(`Guest "${data.name}" added`)
   }
@@ -154,14 +203,21 @@ export function GameSession({
   function handleGuestNameBlur() {
     const name = guestForm.name.trim()
     if (!name) return
-    const existsAlready = guests.some((g) => g.name.toLowerCase() === name.toLowerCase())
+    const existsAlready = guests.some(
+      (g) => g.name.toLowerCase() === name.toLowerCase()
+    )
     if (!existsAlready) {
       addGuest(name)
     }
   }
 
-  async function updateGuestDb(guestId: string, updates: Partial<Pick<GuestPlayer, "cash_in" | "cash_out">>) {
-    setGuests((prev) => prev.map((g) => (g.id === guestId ? { ...g, ...updates } : g)))
+  async function updateGuestDb(
+    guestId: string,
+    updates: Partial<Pick<GuestPlayer, "cash_in" | "cash_out">>
+  ) {
+    setGuests((prev) =>
+      prev.map((g) => (g.id === guestId ? { ...g, ...updates } : g))
+    )
     const supabase = createClient()
     const patch: Record<string, number> = {}
     if (updates.cash_in !== undefined) patch.cash_in = updates.cash_in ?? 0
@@ -202,7 +258,9 @@ export function GameSession({
       setTransferConfirm(false)
       router.refresh()
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to transfer host")
+      toast.error(
+        err instanceof Error ? err.message : "Failed to transfer host"
+      )
     } finally {
       setTransferring(false)
     }
@@ -224,51 +282,88 @@ export function GameSession({
 
     const { data } = await supabase
       .from("game_players")
-      .select("user_id, status, cash_in, cash_out, requested_cash_in, requested_cash_out, profile:profiles(display_name, venmo_handle)")
+      .select(
+        "user_id, status, cash_in, cash_out, requested_cash_in, requested_cash_out, profile:profiles(display_name, venmo_handle)"
+      )
       .eq("game_id", game.id)
     if (data) {
-      const newPlayers = data.map((p: {
-        user_id: string
-        status: string
-        cash_in: number | null
-        cash_out: number | null
-        requested_cash_in: number | null
-        requested_cash_out: number | null
-        profile: { display_name: string | null; venmo_handle: string | null } | { display_name: string | null; venmo_handle: string | null }[] | null
-      }) => {
-        const prof = Array.isArray(p.profile) ? p.profile[0] : p.profile
-        return {
-          user_id: p.user_id,
-          status: p.status as "pending" | "approved" | "denied",
-          cash_in: p.cash_in === null ? null : Number(p.cash_in),
-          cash_out: p.cash_out === null ? null : Number(p.cash_out),
-          requested_cash_in: p.requested_cash_in === null ? (p.cash_in === null ? null : Number(p.cash_in)) : Number(p.requested_cash_in),
-          requested_cash_out: p.requested_cash_out === null ? (p.cash_out === null ? null : Number(p.cash_out)) : Number(p.requested_cash_out),
-          display_name: prof?.display_name ?? null,
-          venmo_handle: prof?.venmo_handle ?? null,
+      const newPlayers = data.map(
+        (p: {
+          user_id: string
+          status: string
+          cash_in: number | null
+          cash_out: number | null
+          requested_cash_in: number | null
+          requested_cash_out: number | null
+          profile:
+            | { display_name: string | null; venmo_handle: string | null }
+            | { display_name: string | null; venmo_handle: string | null }[]
+            | null
+        }) => {
+          const prof = Array.isArray(p.profile) ? p.profile[0] : p.profile
+          return {
+            user_id: p.user_id,
+            status: p.status as "pending" | "approved" | "denied",
+            cash_in: p.cash_in === null ? null : Number(p.cash_in),
+            cash_out: p.cash_out === null ? null : Number(p.cash_out),
+            requested_cash_in:
+              p.requested_cash_in === null
+                ? p.cash_in === null
+                  ? null
+                  : Number(p.cash_in)
+                : Number(p.requested_cash_in),
+            requested_cash_out:
+              p.requested_cash_out === null
+                ? p.cash_out === null
+                  ? null
+                  : Number(p.cash_out)
+                : Number(p.requested_cash_out),
+            display_name: prof?.display_name ?? null,
+            venmo_handle: prof?.venmo_handle ?? null
+          }
         }
-      })
-      
+      )
+
       // Merge with existing players to preserve editing state
-      setPlayers(prevPlayers => {
-        return newPlayers.map(newPlayer => {
-          const existing = prevPlayers.find(p => p.user_id === newPlayer.user_id)
+      setPlayers((prevPlayers) => {
+        return newPlayers.map((newPlayer) => {
+          const existing = prevPlayers.find(
+            (p) => p.user_id === newPlayer.user_id
+          )
           if (!existing) return newPlayer
-          
+
           const ef = editingFieldsRef.current
           const hostEditingCashIn = ef.has(`host-${newPlayer.user_id}-cash_in`)
-          const hostEditingCashOut = ef.has(`host-${newPlayer.user_id}-cash_out`)
-          const selfEditingRequestedIn = ef.has(`self-${newPlayer.user_id}-requested_cash_in`)
-          const selfEditingRequestedOut = ef.has(`self-${newPlayer.user_id}-requested_cash_out`)
-          const pendingEditingRequestedIn = ef.has(`pending-${newPlayer.user_id}-requested_cash_in`)
-          const pendingEditingRequestedOut = ef.has(`pending-${newPlayer.user_id}-requested_cash_out`)
-          
+          const hostEditingCashOut = ef.has(
+            `host-${newPlayer.user_id}-cash_out`
+          )
+          const selfEditingRequestedIn = ef.has(
+            `self-${newPlayer.user_id}-requested_cash_in`
+          )
+          const selfEditingRequestedOut = ef.has(
+            `self-${newPlayer.user_id}-requested_cash_out`
+          )
+          const pendingEditingRequestedIn = ef.has(
+            `pending-${newPlayer.user_id}-requested_cash_in`
+          )
+          const pendingEditingRequestedOut = ef.has(
+            `pending-${newPlayer.user_id}-requested_cash_out`
+          )
+
           return {
             ...newPlayer,
             cash_in: hostEditingCashIn ? existing.cash_in : newPlayer.cash_in,
-            cash_out: hostEditingCashOut ? existing.cash_out : newPlayer.cash_out,
-            requested_cash_in: (selfEditingRequestedIn || pendingEditingRequestedIn) ? existing.requested_cash_in : newPlayer.requested_cash_in,
-            requested_cash_out: (selfEditingRequestedOut || pendingEditingRequestedOut) ? existing.requested_cash_out : newPlayer.requested_cash_out,
+            cash_out: hostEditingCashOut
+              ? existing.cash_out
+              : newPlayer.cash_out,
+            requested_cash_in:
+              selfEditingRequestedIn || pendingEditingRequestedIn
+                ? existing.requested_cash_in
+                : newPlayer.requested_cash_in,
+            requested_cash_out:
+              selfEditingRequestedOut || pendingEditingRequestedOut
+                ? existing.requested_cash_out
+                : newPlayer.requested_cash_out
           }
         })
       })
@@ -280,26 +375,37 @@ export function GameSession({
       .select("id, name, cash_in, cash_out")
       .eq("game_id", game.id)
     if (guestData) {
-      const newGuests = guestData.map((g: { id: string; name: string; cash_in: number; cash_out: number }) => ({
-        id: g.id,
-        name: g.name,
-        cash_in: g.cash_in,
-        cash_out: g.cash_out,
-      }))
-      
+      const newGuests = guestData.map(
+        (g: {
+          id: string
+          name: string
+          cash_in: number
+          cash_out: number
+        }) => ({
+          id: g.id,
+          name: g.name,
+          cash_in: g.cash_in,
+          cash_out: g.cash_out
+        })
+      )
+
       // Merge with existing guests to preserve editing state
-      setGuests(prevGuests => {
-        return newGuests.map(newGuest => {
-          const existing = prevGuests.find(g => g.id === newGuest.id)
+      setGuests((prevGuests) => {
+        return newGuests.map((newGuest) => {
+          const existing = prevGuests.find((g) => g.id === newGuest.id)
           if (!existing) return newGuest
-          
-          const editingCashIn = editingFieldsRef.current.has(`guest-${newGuest.id}-cash_in`)
-          const editingCashOut = editingFieldsRef.current.has(`guest-${newGuest.id}-cash_out`)
-          
+
+          const editingCashIn = editingFieldsRef.current.has(
+            `guest-${newGuest.id}-cash_in`
+          )
+          const editingCashOut = editingFieldsRef.current.has(
+            `guest-${newGuest.id}-cash_out`
+          )
+
           return {
             ...newGuest,
             cash_in: editingCashIn ? existing.cash_in : newGuest.cash_in,
-            cash_out: editingCashOut ? existing.cash_out : newGuest.cash_out,
+            cash_out: editingCashOut ? existing.cash_out : newGuest.cash_out
           }
         })
       })
@@ -354,20 +460,25 @@ export function GameSession({
   }, [game.id])
 
   const gameForPayout = useMemo((): GameSchema | null => {
-    const allGamePlayers = [...approved, ...guests.filter(g => g.cash_in !== null || g.cash_out !== null)]
+    const allGamePlayers = [
+      ...approved,
+      ...guests.filter((g) => g.cash_in !== null || g.cash_out !== null)
+    ]
     if (allGamePlayers.length < 2) return null
-    
+
     const names = new Set<string>()
     const makeName = (p: PlayerRow | GuestPlayer) => {
       let base: string
-      if ('venmo_handle' in p) {
+      if ("venmo_handle" in p) {
         // Regular player
-        base = p.venmo_handle ? `@${p.venmo_handle}` : p.display_name || `Player_${p.user_id.slice(0, 8)}`
+        base = p.venmo_handle
+          ? `@${p.venmo_handle}`
+          : p.display_name || `Player_${p.user_id.slice(0, 8)}`
       } else {
         // Guest player
         base = `${p.name} (guest)`
       }
-      
+
       let name = base
       let n = 0
       while (names.has(name)) {
@@ -376,7 +487,7 @@ export function GameSession({
       names.add(name)
       return name
     }
-    
+
     const players = [
       ...approved.map((p) => ({
         name: makeName(p),
@@ -384,21 +495,24 @@ export function GameSession({
         cashOut: p.cash_out ?? 0
       })),
       ...guests
-        .filter(g => g.cash_in !== null || g.cash_out !== null)
+        .filter((g) => g.cash_in !== null || g.cash_out !== null)
         .map((g) => ({
           name: makeName(g),
           cashIn: g.cash_in ?? 0,
           cashOut: g.cash_out ?? 0
         }))
     ]
-    
+
     return {
       description: game.description || undefined,
       players
     }
   }, [approved, guests, game.description])
 
-  const payout = useMemo(() => (gameForPayout ? calcPayouts(gameForPayout) : null), [gameForPayout])
+  const payout = useMemo(
+    () => (gameForPayout ? calcPayouts(gameForPayout) : null),
+    [gameForPayout]
+  )
 
   async function updatePlayerFields(
     gameId: string,
@@ -406,7 +520,11 @@ export function GameSession({
     patch: Partial<
       Pick<
         PlayerRow,
-        "cash_in" | "cash_out" | "requested_cash_in" | "requested_cash_out" | "status"
+        | "cash_in"
+        | "cash_out"
+        | "requested_cash_in"
+        | "requested_cash_out"
+        | "status"
       >
     >
   ) {
@@ -423,7 +541,12 @@ export function GameSession({
     setUpdating(null)
   }
 
-  async function updateCash(gameId: string, userId: string, cash_in: number | null, cash_out: number | null) {
+  async function updateCash(
+    gameId: string,
+    userId: string,
+    cash_in: number | null,
+    cash_out: number | null
+  ) {
     await updatePlayerFields(gameId, userId, {
       cash_in,
       cash_out,
@@ -444,7 +567,11 @@ export function GameSession({
     })
   }
 
-  async function setStatus(gameId: string, userId: string, status: "approved" | "denied") {
+  async function setStatus(
+    gameId: string,
+    userId: string,
+    status: "approved" | "denied"
+  ) {
     await updatePlayerFields(gameId, userId, { status })
   }
 
@@ -454,26 +581,28 @@ export function GameSession({
       const newStatus = isClosed ? "active" : "closed"
       await setGameStatus(game.id, newStatus)
       setGameStatus_(newStatus)
-      
+
       // When reopening: zero out all player amounts locally so the UI starts fresh
       if (newStatus === "active") {
-        setPlayers(prev =>
-          prev.map(p => ({
+        setPlayers((prev) =>
+          prev.map((p) => ({
             ...p,
             cash_in: 0,
             cash_out: 0,
             requested_cash_in: 0,
-            requested_cash_out: 0,
+            requested_cash_out: 0
           }))
         )
-        
+
         // Force a fresh fetch after a short delay to ensure server changes are applied
         setTimeout(() => {
           fetchAll()
         }, 500)
       }
-      
-      toast.success(isClosed ? "Session reopened" : "Session closed — edits are locked")
+
+      toast.success(
+        isClosed ? "Session reopened" : "Session closed — edits are locked"
+      )
     } catch (e) {
       toast.error((e as Error).message)
     } finally {
@@ -482,29 +611,38 @@ export function GameSession({
   }
 
   async function handleEndGame() {
-    if (!payout || !gameForPayout || (approved.length + guests.filter(g => g.cash_in !== null || g.cash_out !== null).length) < 2) return
+    if (
+      !payout ||
+      !gameForPayout ||
+      approved.length +
+        guests.filter((g) => g.cash_in !== null || g.cash_out !== null).length <
+        2
+    )
+      return
     setEnding(true)
     const nameToUserId = new Map<string, string>()
-    
+
     // Map approved players to user IDs
     approved.forEach((player) => {
-      const playerName = gameForPayout.players.find(gp => {
-        const base = player.venmo_handle ? `@${player.venmo_handle}` : player.display_name || `Player_${player.user_id.slice(0, 8)}`
-        return gp.name === base || gp.name.startsWith(base + '_')
+      const playerName = gameForPayout.players.find((gp) => {
+        const base = player.venmo_handle
+          ? `@${player.venmo_handle}`
+          : player.display_name || `Player_${player.user_id.slice(0, 8)}`
+        return gp.name === base || gp.name.startsWith(base + "_")
       })?.name
       if (playerName) {
         nameToUserId.set(playerName, player.user_id)
       }
     })
-    
+
     // Create profit deltas only for players with user IDs (excluding guests)
     const profit_deltas = payout.players
-      .filter(pl => nameToUserId.has(pl.name)) // Only include players with user IDs
+      .filter((pl) => nameToUserId.has(pl.name)) // Only include players with user IDs
       .map((pl) => ({
         user_id: nameToUserId.get(pl.name)!,
         profit_delta: pl.net
       }))
-    
+
     // Note: We don't validate that all payout players have user IDs since guests won't have them
     const supabase = createClient()
     const { error } = await supabase.rpc("end_game", {
@@ -523,6 +661,8 @@ export function GameSession({
 
   function copyGameLink() {
     navigator.clipboard.writeText(inviteUrl)
+    setCopyFeedback("Invite link copied")
+    window.setTimeout(() => setCopyFeedback(""), 2000)
     toast.success("Link copied")
   }
 
@@ -546,7 +686,8 @@ export function GameSession({
           <div>
             <CardTitle>{game.description || "Game"}</CardTitle>
             <CardDescription>
-              Game ID: <span className="font-mono">{game.short_code}</span> — share so others can join
+              Game ID: <span className="font-mono">{game.short_code}</span> —
+              share so others can join
               <br />
               Invite link:{" "}
               <span className="font-mono break-all">{inviteUrl}</span>
@@ -576,13 +717,18 @@ export function GameSession({
             </Button>
           </div>
         </CardHeader>
+        <div className="sr-only" aria-live="polite">
+          {copyFeedback}
+        </div>
       </Card>
 
       {pending.length > 0 && isHost && (
         <Card>
           <CardHeader>
             <CardTitle>Pending approval</CardTitle>
-            <CardDescription>Approve or deny players to join the game</CardDescription>
+            <CardDescription>
+              Approve or deny players to join the game
+            </CardDescription>
           </CardHeader>
           <CardContent className="space-y-2">
             {pending.map((p) => (
@@ -593,13 +739,15 @@ export function GameSession({
                 <div className="flex flex-col gap-1">
                   <span>{p.display_name || p.user_id.slice(0, 8)}</span>
                   <span className="text-xs text-muted-foreground">
-                    Requested in: {p.requested_cash_in ?? 0} / out: {p.requested_cash_out ?? 0}
+                    Requested in: {p.requested_cash_in ?? 0} / out:{" "}
+                    {p.requested_cash_out ?? 0}
                   </span>
                 </div>
                 <div className="flex gap-1">
                   <Button
                     size="sm"
                     variant="default"
+                    aria-label={`Approve ${playerName(p)}`}
                     disabled={updating === p.user_id}
                     onClick={() =>
                       updatePlayerFields(game.id, p.user_id, {
@@ -611,12 +759,17 @@ export function GameSession({
                       })
                     }
                   >
-                    {updating === p.user_id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
+                    {updating === p.user_id ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Check className="h-4 w-4" />
+                    )}
                     Approve
                   </Button>
                   <Button
                     size="sm"
                     variant="destructive"
+                    aria-label={`Deny ${playerName(p)}`}
                     disabled={updating === p.user_id}
                     onClick={() => setStatus(game.id, p.user_id, "denied")}
                   >
@@ -640,7 +793,10 @@ export function GameSession({
           </CardDescription>
         </CardHeader>
         {isClosed && (
-          <div className="mx-6 mb-2 flex items-center gap-2 rounded-md border border-yellow-500/40 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-500">
+          <div
+            className="mx-6 mb-2 flex items-center gap-2 rounded-md border border-yellow-600/40 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-700 dark:text-yellow-300"
+            role="status"
+          >
             <Lock className="h-4 w-4 shrink-0" />
             Session closed — all edits are locked until the host reopens it.
           </div>
@@ -650,28 +806,37 @@ export function GameSession({
             {players.map((p) => (
               <div
                 key={p.user_id}
+                role="group"
+                aria-label={`${playerName(p)} ${p.status} player`}
                 className="flex flex-wrap items-center gap-2 rounded border p-2"
               >
                 {/* Player name: host can click approved players to open action modal */}
                 <span className="font-medium">
-                  {isHost && p.status === "approved" && p.user_id !== currentUserId ? (
+                  {isHost &&
+                  p.status === "approved" &&
+                  p.user_id !== currentUserId ? (
                     <button
-                      className="cursor-pointer text-left underline underline-offset-2 decoration-white"
+                      className="cursor-pointer rounded-sm text-left underline underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                      aria-label={`Open actions for ${playerName(p)}`}
                       onClick={() => {
                         setSelectedPlayer(p)
                         setTransferConfirm(false)
                       }}
                     >
-                      {p.display_name || p.user_id.slice(0, 8)}
+                      {playerName(p)}
                     </button>
                   ) : (
-                    p.display_name || p.user_id.slice(0, 8)
+                    playerName(p)
                   )}
                   {p.status === "pending" && (
-                    <span className="text-muted-foreground ml-1 text-sm">(pending)</span>
+                    <span className="text-muted-foreground ml-1 text-sm">
+                      (pending)
+                    </span>
                   )}
                   {p.status === "denied" && (
-                    <span className="text-muted-foreground ml-1 text-sm">(denied)</span>
+                    <span className="text-muted-foreground ml-1 text-sm">
+                      (denied)
+                    </span>
                   )}
                 </span>
                 {p.status === "approved" && (
@@ -683,118 +848,152 @@ export function GameSession({
                           <Input
                             className="w-24"
                             placeholder="In"
-                            value={p.cash_in === null || p.cash_in === undefined ? "" : p.cash_in.toString()}
-                            onFocus={() => setFieldEditing(`host-${p.user_id}-cash_in`, true)}
+                            aria-label={`Cash in for ${playerName(p)}`}
+                            inputMode="decimal"
+                            value={
+                              p.cash_in === null || p.cash_in === undefined
+                                ? ""
+                                : p.cash_in.toString()
+                            }
+                            onFocus={() =>
+                              setFieldEditing(`host-${p.user_id}-cash_in`, true)
+                            }
                             onChange={(e) => {
                               const v = parseCashInput(e.target.value)
                               setPlayers((prev) =>
                                 prev.map((x) =>
-                                  x.user_id === p.user_id ? { ...x, cash_in: v } : x
+                                  x.user_id === p.user_id
+                                    ? { ...x, cash_in: v }
+                                    : x
                                 )
                               )
                             }}
                             onBlur={(e) => {
                               const v = parseCashInput(e.target.value)
-                              setFieldEditing(`host-${p.user_id}-cash_in`, false)
+                              setFieldEditing(
+                                `host-${p.user_id}-cash_in`,
+                                false
+                              )
                               updateCash(game.id, p.user_id, v, p.cash_out)
                             }}
                           />
                           <Input
                             className="w-24"
                             placeholder="Out"
-                            value={p.cash_out === null || p.cash_out === undefined ? "" : p.cash_out.toString()}
-                            onFocus={() => setFieldEditing(`host-${p.user_id}-cash_out`, true)}
+                            aria-label={`Cash out for ${playerName(p)}`}
+                            inputMode="decimal"
+                            value={
+                              p.cash_out === null || p.cash_out === undefined
+                                ? ""
+                                : p.cash_out.toString()
+                            }
+                            onFocus={() =>
+                              setFieldEditing(
+                                `host-${p.user_id}-cash_out`,
+                                true
+                              )
+                            }
                             onChange={(e) => {
                               const v = parseCashInput(e.target.value)
                               setPlayers((prev) =>
                                 prev.map((x) =>
-                                  x.user_id === p.user_id ? { ...x, cash_out: v } : x
+                                  x.user_id === p.user_id
+                                    ? { ...x, cash_out: v }
+                                    : x
                                 )
                               )
                             }}
                             onBlur={(e) => {
                               const v = parseCashInput(e.target.value)
-                              setFieldEditing(`host-${p.user_id}-cash_out`, false)
+                              setFieldEditing(
+                                `host-${p.user_id}-cash_out`,
+                                false
+                              )
                               updateCash(game.id, p.user_id, p.cash_in, v)
                             }}
                           />
                         </div>
-                        {!isClosed && (p.requested_cash_in !== p.cash_in || p.requested_cash_out !== p.cash_out) && (
-                          <div className="flex flex-col gap-1 text-xs text-muted-foreground">
-                            {p.requested_cash_in !== p.cash_in && (
-                              <div className="flex items-center justify-between gap-2">
-                                <span className="flex-1">
-                                  Requested in: {p.requested_cash_in ?? 0} (current {p.cash_in ?? 0})
-                                </span>
-                                <div className="flex gap-1 shrink-0">
-                                  <Button
-                                    size="sm"
-                                    variant="outline"
-                                    disabled={updating === p.user_id}
-                                    onClick={() =>
-                                      updatePlayerFields(game.id, p.user_id, {
-                                        cash_in: p.requested_cash_in,
-                                        requested_cash_in: p.requested_cash_in
-                                      })
-                                    }
-                                  >
-                                    <Check className="mr-1 h-3 w-3" />
-                                    Approve
-                                  </Button>
-                                  <Button
-                                    size="sm"
-                                    variant="ghost"
-                                    disabled={updating === p.user_id}
-                                    onClick={() =>
-                                      updatePlayerFields(game.id, p.user_id, {
-                                        requested_cash_in: p.cash_in
-                                      })
-                                    }
-                                  >
-                                    <X className="mr-1 h-3 w-3" />
-                                    Deny
-                                  </Button>
+                        {!isClosed &&
+                          (p.requested_cash_in !== p.cash_in ||
+                            p.requested_cash_out !== p.cash_out) && (
+                            <div className="flex flex-col gap-1 text-xs text-muted-foreground">
+                              {p.requested_cash_in !== p.cash_in && (
+                                <div className="flex items-center justify-between gap-2">
+                                  <span className="flex-1">
+                                    Requested in: {p.requested_cash_in ?? 0}{" "}
+                                    (current {p.cash_in ?? 0})
+                                  </span>
+                                  <div className="flex gap-1 shrink-0">
+                                    <Button
+                                      size="sm"
+                                      variant="outline"
+                                      disabled={updating === p.user_id}
+                                      onClick={() =>
+                                        updatePlayerFields(game.id, p.user_id, {
+                                          cash_in: p.requested_cash_in,
+                                          requested_cash_in: p.requested_cash_in
+                                        })
+                                      }
+                                    >
+                                      <Check className="mr-1 h-3 w-3" />
+                                      Approve
+                                    </Button>
+                                    <Button
+                                      size="sm"
+                                      variant="ghost"
+                                      disabled={updating === p.user_id}
+                                      onClick={() =>
+                                        updatePlayerFields(game.id, p.user_id, {
+                                          requested_cash_in: p.cash_in
+                                        })
+                                      }
+                                    >
+                                      <X className="mr-1 h-3 w-3" />
+                                      Deny
+                                    </Button>
+                                  </div>
                                 </div>
-                              </div>
-                            )}
-                            {p.requested_cash_out !== p.cash_out && (
-                              <div className="flex items-center justify-between gap-2">
-                                <span className="flex-1">
-                                  Requested out: {p.requested_cash_out ?? 0} (current {p.cash_out ?? 0})
-                                </span>
-                                <div className="flex gap-1 shrink-0">
-                                  <Button
-                                    size="sm"
-                                    variant="outline"
-                                    disabled={updating === p.user_id}
-                                    onClick={() =>
-                                      updatePlayerFields(game.id, p.user_id, {
-                                        cash_out: p.requested_cash_out,
-                                        requested_cash_out: p.requested_cash_out
-                                      })
-                                    }
-                                  >
-                                    <Check className="mr-1 h-3 w-3" />
-                                    Approve
-                                  </Button>
-                                  <Button
-                                    size="sm"
-                                    variant="ghost"
-                                    disabled={updating === p.user_id}
-                                    onClick={() =>
-                                      updatePlayerFields(game.id, p.user_id, {
-                                        requested_cash_out: p.cash_out
-                                      })
-                                    }
-                                  >
-                                    <X className="mr-1 h-3 w-3" />
-                                    Deny
-                                  </Button>
+                              )}
+                              {p.requested_cash_out !== p.cash_out && (
+                                <div className="flex items-center justify-between gap-2">
+                                  <span className="flex-1">
+                                    Requested out: {p.requested_cash_out ?? 0}{" "}
+                                    (current {p.cash_out ?? 0})
+                                  </span>
+                                  <div className="flex gap-1 shrink-0">
+                                    <Button
+                                      size="sm"
+                                      variant="outline"
+                                      disabled={updating === p.user_id}
+                                      onClick={() =>
+                                        updatePlayerFields(game.id, p.user_id, {
+                                          cash_out: p.requested_cash_out,
+                                          requested_cash_out:
+                                            p.requested_cash_out
+                                        })
+                                      }
+                                    >
+                                      <Check className="mr-1 h-3 w-3" />
+                                      Approve
+                                    </Button>
+                                    <Button
+                                      size="sm"
+                                      variant="ghost"
+                                      disabled={updating === p.user_id}
+                                      onClick={() =>
+                                        updatePlayerFields(game.id, p.user_id, {
+                                          requested_cash_out: p.cash_out
+                                        })
+                                      }
+                                    >
+                                      <X className="mr-1 h-3 w-3" />
+                                      Deny
+                                    </Button>
+                                  </div>
                                 </div>
-                              </div>
-                            )}
-                          </div>
-                        )}
+                              )}
+                            </div>
+                          )}
                       </div>
                     )}
 
@@ -805,45 +1004,91 @@ export function GameSession({
                           <Input
                             className="w-24"
                             placeholder="In"
-                            value={p.requested_cash_in === null || p.requested_cash_in === undefined ? "" : p.requested_cash_in.toString()}
-                            onFocus={() => setFieldEditing(`self-${p.user_id}-requested_cash_in`, true)}
+                            aria-label={`Requested cash in for ${playerName(p)}`}
+                            inputMode="decimal"
+                            value={
+                              p.requested_cash_in === null ||
+                              p.requested_cash_in === undefined
+                                ? ""
+                                : p.requested_cash_in.toString()
+                            }
+                            onFocus={() =>
+                              setFieldEditing(
+                                `self-${p.user_id}-requested_cash_in`,
+                                true
+                              )
+                            }
                             onChange={(e) => {
                               const v = parseCashInput(e.target.value)
                               setPlayers((prev) =>
                                 prev.map((x) =>
-                                  x.user_id === p.user_id ? { ...x, requested_cash_in: v } : x
+                                  x.user_id === p.user_id
+                                    ? { ...x, requested_cash_in: v }
+                                    : x
                                 )
                               )
                             }}
                             onBlur={(e) => {
                               const v = parseCashInput(e.target.value)
-                              setFieldEditing(`self-${p.user_id}-requested_cash_in`, false)
-                              updateRequestedCash(game.id, p.user_id, v, p.requested_cash_out)
+                              setFieldEditing(
+                                `self-${p.user_id}-requested_cash_in`,
+                                false
+                              )
+                              updateRequestedCash(
+                                game.id,
+                                p.user_id,
+                                v,
+                                p.requested_cash_out
+                              )
                             }}
                           />
                           <Input
                             className="w-24"
                             placeholder="Out"
-                            value={p.requested_cash_out === null || p.requested_cash_out === undefined ? "" : p.requested_cash_out.toString()}
-                            onFocus={() => setFieldEditing(`self-${p.user_id}-requested_cash_out`, true)}
+                            aria-label={`Requested cash out for ${playerName(p)}`}
+                            inputMode="decimal"
+                            value={
+                              p.requested_cash_out === null ||
+                              p.requested_cash_out === undefined
+                                ? ""
+                                : p.requested_cash_out.toString()
+                            }
+                            onFocus={() =>
+                              setFieldEditing(
+                                `self-${p.user_id}-requested_cash_out`,
+                                true
+                              )
+                            }
                             onChange={(e) => {
                               const v = parseCashInput(e.target.value)
                               setPlayers((prev) =>
                                 prev.map((x) =>
-                                  x.user_id === p.user_id ? { ...x, requested_cash_out: v } : x
+                                  x.user_id === p.user_id
+                                    ? { ...x, requested_cash_out: v }
+                                    : x
                                 )
                               )
                             }}
                             onBlur={(e) => {
                               const v = parseCashInput(e.target.value)
-                              setFieldEditing(`self-${p.user_id}-requested_cash_out`, false)
-                              updateRequestedCash(game.id, p.user_id, p.requested_cash_in, v)
+                              setFieldEditing(
+                                `self-${p.user_id}-requested_cash_out`,
+                                false
+                              )
+                              updateRequestedCash(
+                                game.id,
+                                p.user_id,
+                                p.requested_cash_in,
+                                v
+                              )
                             }}
                           />
                         </div>
                         <span className="text-xs text-muted-foreground">
-                          Current approved: In {p.cash_in ?? 0} / Out {p.cash_out ?? 0}
-                          {(p.requested_cash_in !== p.cash_in || p.requested_cash_out !== p.cash_out) &&
+                          Current approved: In {p.cash_in ?? 0} / Out{" "}
+                          {p.cash_out ?? 0}
+                          {(p.requested_cash_in !== p.cash_in ||
+                            p.requested_cash_out !== p.cash_out) &&
                             " — awaiting host approval"}
                         </span>
                       </div>
@@ -864,112 +1109,178 @@ export function GameSession({
                     )}
                   </>
                 )}
-                {p.status === "pending" && !isHost && p.user_id === currentUserId && !isClosed && (
-                  <div className="flex flex-col gap-1">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Input
-                        className="w-24"
-                        placeholder="Requested in"
-                        value={p.requested_cash_in === null || p.requested_cash_in === undefined ? "" : p.requested_cash_in.toString()}
-                        onFocus={() => setFieldEditing(`pending-${p.user_id}-requested_cash_in`, true)}
-                        onChange={(e) => {
-                          const v = e.target.value === "" ? null : parseFloat(e.target.value) || null
-                          setPlayers((prev) =>
-                            prev.map((x) =>
-                              x.user_id === p.user_id ? { ...x, requested_cash_in: v } : x
+                {p.status === "pending" &&
+                  !isHost &&
+                  p.user_id === currentUserId &&
+                  !isClosed && (
+                    <div className="flex flex-col gap-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Input
+                          className="w-24"
+                          placeholder="Requested in"
+                          aria-label={`Requested cash in for ${playerName(p)}`}
+                          inputMode="decimal"
+                          value={
+                            p.requested_cash_in === null ||
+                            p.requested_cash_in === undefined
+                              ? ""
+                              : p.requested_cash_in.toString()
+                          }
+                          onFocus={() =>
+                            setFieldEditing(
+                              `pending-${p.user_id}-requested_cash_in`,
+                              true
                             )
-                          )
-                        }}
-                        onBlur={(e) => {
-                          const v = e.target.value === "" ? null : parseFloat(e.target.value) || null
-                          setFieldEditing(`pending-${p.user_id}-requested_cash_in`, false)
-                          updateRequestedAmounts(game.id, v ?? 0, p.requested_cash_out ?? 0).catch(() =>
-                            toast.error("Failed to save")
-                          )
-                        }}
-                      />
-                      <Input
-                        className="w-24"
-                        placeholder="Requested out"
-                        value={p.requested_cash_out === null || p.requested_cash_out === undefined ? "" : p.requested_cash_out.toString()}
-                        onFocus={() => setFieldEditing(`pending-${p.user_id}-requested_cash_out`, true)}
-                        onChange={(e) => {
-                          const v = e.target.value === "" ? null : parseFloat(e.target.value) || null
-                          setPlayers((prev) =>
-                            prev.map((x) =>
-                              x.user_id === p.user_id ? { ...x, requested_cash_out: v } : x
+                          }
+                          onChange={(e) => {
+                            const v =
+                              e.target.value === ""
+                                ? null
+                                : parseFloat(e.target.value) || null
+                            setPlayers((prev) =>
+                              prev.map((x) =>
+                                x.user_id === p.user_id
+                                  ? { ...x, requested_cash_in: v }
+                                  : x
+                              )
                             )
-                          )
-                        }}
-                        onBlur={(e) => {
-                          const v = e.target.value === "" ? null : parseFloat(e.target.value) || null
-                          setFieldEditing(`pending-${p.user_id}-requested_cash_out`, false)
-                          updateRequestedAmounts(game.id, p.requested_cash_in ?? 0, v ?? 0).catch(() =>
-                            toast.error("Failed to save")
-                          )
-                        }}
-                      />
+                          }}
+                          onBlur={(e) => {
+                            const v =
+                              e.target.value === ""
+                                ? null
+                                : parseFloat(e.target.value) || null
+                            setFieldEditing(
+                              `pending-${p.user_id}-requested_cash_in`,
+                              false
+                            )
+                            updateRequestedAmounts(
+                              game.id,
+                              v ?? 0,
+                              p.requested_cash_out ?? 0
+                            ).catch(() => toast.error("Failed to save"))
+                          }}
+                        />
+                        <Input
+                          className="w-24"
+                          placeholder="Requested out"
+                          aria-label={`Requested cash out for ${playerName(p)}`}
+                          inputMode="decimal"
+                          value={
+                            p.requested_cash_out === null ||
+                            p.requested_cash_out === undefined
+                              ? ""
+                              : p.requested_cash_out.toString()
+                          }
+                          onFocus={() =>
+                            setFieldEditing(
+                              `pending-${p.user_id}-requested_cash_out`,
+                              true
+                            )
+                          }
+                          onChange={(e) => {
+                            const v =
+                              e.target.value === ""
+                                ? null
+                                : parseFloat(e.target.value) || null
+                            setPlayers((prev) =>
+                              prev.map((x) =>
+                                x.user_id === p.user_id
+                                  ? { ...x, requested_cash_out: v }
+                                  : x
+                              )
+                            )
+                          }}
+                          onBlur={(e) => {
+                            const v =
+                              e.target.value === ""
+                                ? null
+                                : parseFloat(e.target.value) || null
+                            setFieldEditing(
+                              `pending-${p.user_id}-requested_cash_out`,
+                              false
+                            )
+                            updateRequestedAmounts(
+                              game.id,
+                              p.requested_cash_in ?? 0,
+                              v ?? 0
+                            ).catch(() => toast.error("Failed to save"))
+                          }}
+                        />
+                      </div>
+                      <span className="text-xs text-muted-foreground">
+                        Waiting for host to approve your join request and
+                        amounts.
+                      </span>
                     </div>
-                    <span className="text-xs text-muted-foreground">
-                      Waiting for host to approve your join request and amounts.
-                    </span>
-                  </div>
-                )}
+                  )}
                 {/* Denied self: offer to request rejoin */}
-                {!isHost && p.user_id === currentUserId && p.status === "denied" && (
-                  <div className="flex flex-col gap-1">
-                    <span className="text-xs text-red-400">
-                      You were removed from this table.
-                    </span>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      disabled={updating === p.user_id}
-                      onClick={async () => {
-                        setUpdating(p.user_id)
-                        try {
-                          await requestRejoin(game.id)
-                          // Optimistically flip to pending in local state
-                          setPlayers((prev) =>
-                            prev.map((x) =>
-                              x.user_id === p.user_id ? { ...x, status: "pending" } : x
+                {!isHost &&
+                  p.user_id === currentUserId &&
+                  p.status === "denied" && (
+                    <div className="flex flex-col gap-1">
+                      <span className="text-destructive text-xs">
+                        You were removed from this table.
+                      </span>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={updating === p.user_id}
+                        onClick={async () => {
+                          setUpdating(p.user_id)
+                          try {
+                            await requestRejoin(game.id)
+                            // Optimistically flip to pending in local state
+                            setPlayers((prev) =>
+                              prev.map((x) =>
+                                x.user_id === p.user_id
+                                  ? { ...x, status: "pending" }
+                                  : x
+                              )
                             )
-                          )
-                          toast.success("Rejoin request sent — waiting for host approval")
-                        } catch {
-                          toast.error("Failed to send rejoin request")
-                        } finally {
-                          setUpdating(null)
-                        }
-                      }}
-                    >
-                      {updating === p.user_id
-                        ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                        : null}
-                      Request to Rejoin
-                    </Button>
-                  </div>
-                )}
+                            toast.success(
+                              "Rejoin request sent — waiting for host approval"
+                            )
+                          } catch {
+                            toast.error("Failed to send rejoin request")
+                          } finally {
+                            setUpdating(null)
+                          }
+                        }}
+                      >
+                        {updating === p.user_id ? (
+                          <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                        ) : null}
+                        Request to Rejoin
+                      </Button>
+                    </div>
+                  )}
 
                 {/* Action button — host only, not on self */}
                 {isHost && p.user_id !== currentUserId && (
                   <button
-                    className={`ml-auto flex h-6 w-6 items-center justify-center rounded-full transition-colors disabled:opacity-40 ${
+                    className={`ml-auto flex h-8 w-8 items-center justify-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-40 ${
                       p.status === "denied"
                         ? "text-muted-foreground hover:bg-green-500/10 hover:text-green-500"
                         : "text-muted-foreground hover:bg-red-500/10 hover:text-red-500"
                     }`}
-                    title={p.status === "denied" ? "Approve player" : "Remove player"}
+                    aria-label={
+                      p.status === "denied"
+                        ? `Approve ${playerName(p)}`
+                        : `Remove ${playerName(p)}`
+                    }
                     disabled={kicking === p.user_id || updating === p.user_id}
                     onClick={() => {
                       if (p.status === "denied") {
-                        updatePlayerFields(game.id, p.user_id, { status: "approved" })
+                        updatePlayerFields(game.id, p.user_id, {
+                          status: "approved"
+                        })
                       } else {
                         handleKick(p.user_id)
                       }
                     }}
                   >
-                    {(kicking === p.user_id || updating === p.user_id) ? (
+                    {kicking === p.user_id || updating === p.user_id ? (
                       <Loader2 className="h-3.5 w-3.5 animate-spin" />
                     ) : p.status === "denied" ? (
                       <Check className="h-3.5 w-3.5" />
@@ -980,27 +1291,43 @@ export function GameSession({
                 )}
               </div>
             ))}
-            
+
             {/* Guest section — visible to everyone, editable by host */}
             {guests.map((guest) => (
               <div
                 key={guest.id}
+                role="group"
+                aria-label={`${guest.name} guest player`}
                 className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-2 rounded border p-3"
               >
                 <span className="font-medium flex-shrink-0">
                   {guest.name}
-                  <span className="text-muted-foreground ml-1 text-sm">(guest)</span>
+                  <span className="text-muted-foreground ml-1 text-sm">
+                    (guest)
+                  </span>
                 </span>
                 {isHost ? (
                   <div className="flex items-center gap-2 sm:flex-1">
                     <Input
                       className="flex-1 sm:w-24 sm:flex-initial"
                       placeholder="In"
-                      value={guest.cash_in === null || guest.cash_in === undefined ? "" : guest.cash_in.toString()}
-                      onFocus={() => setFieldEditing(`guest-${guest.id}-cash_in`, true)}
+                      aria-label={`Cash in for guest ${guest.name}`}
+                      inputMode="decimal"
+                      value={
+                        guest.cash_in === null || guest.cash_in === undefined
+                          ? ""
+                          : guest.cash_in.toString()
+                      }
+                      onFocus={() =>
+                        setFieldEditing(`guest-${guest.id}-cash_in`, true)
+                      }
                       onChange={(e) => {
                         const v = parseCashInput(e.target.value)
-                        setGuests((prev) => prev.map((g) => (g.id === guest.id ? { ...g, cash_in: v } : g)))
+                        setGuests((prev) =>
+                          prev.map((g) =>
+                            g.id === guest.id ? { ...g, cash_in: v } : g
+                          )
+                        )
                       }}
                       onBlur={(e) => {
                         const v = parseCashInput(e.target.value)
@@ -1012,11 +1339,23 @@ export function GameSession({
                     <Input
                       className="flex-1 sm:w-24 sm:flex-initial"
                       placeholder="Out"
-                      value={guest.cash_out === null || guest.cash_out === undefined ? "" : guest.cash_out.toString()}
-                      onFocus={() => setFieldEditing(`guest-${guest.id}-cash_out`, true)}
+                      aria-label={`Cash out for guest ${guest.name}`}
+                      inputMode="decimal"
+                      value={
+                        guest.cash_out === null || guest.cash_out === undefined
+                          ? ""
+                          : guest.cash_out.toString()
+                      }
+                      onFocus={() =>
+                        setFieldEditing(`guest-${guest.id}-cash_out`, true)
+                      }
                       onChange={(e) => {
                         const v = parseCashInput(e.target.value)
-                        setGuests((prev) => prev.map((g) => (g.id === guest.id ? { ...g, cash_out: v } : g)))
+                        setGuests((prev) =>
+                          prev.map((g) =>
+                            g.id === guest.id ? { ...g, cash_out: v } : g
+                          )
+                        )
                       }}
                       onBlur={(e) => {
                         const v = parseCashInput(e.target.value)
@@ -1026,8 +1365,8 @@ export function GameSession({
                       disabled={isClosed}
                     />
                     <button
-                      className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:bg-red-500/10 hover:text-red-500 transition-colors"
-                      title="Remove guest"
+                      className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-red-500/10 hover:text-red-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                      aria-label={`Remove guest ${guest.name}`}
                       onClick={() => removeGuest(guest.id)}
                     >
                       <X className="h-3.5 w-3.5" />
@@ -1047,6 +1386,7 @@ export function GameSession({
                 <Input
                   className="flex-1 sm:flex-initial sm:w-32 min-w-0"
                   placeholder="Guest name"
+                  aria-label="Guest name"
                   value={guestForm.name}
                   onChange={(e) => handleGuestNameChange(e.target.value)}
                   onBlur={handleGuestNameBlur}
@@ -1055,14 +1395,28 @@ export function GameSession({
                   <Input
                     className="flex-1 sm:w-24"
                     placeholder="In"
+                    aria-label="Cash in for new guest"
+                    inputMode="decimal"
                     value={guestForm.cash_in}
-                    onChange={(e) => setGuestForm((prev) => ({ ...prev, cash_in: e.target.value }))}
+                    onChange={(e) =>
+                      setGuestForm((prev) => ({
+                        ...prev,
+                        cash_in: e.target.value
+                      }))
+                    }
                   />
                   <Input
                     className="flex-1 sm:w-24"
                     placeholder="Out"
+                    aria-label="Cash out for new guest"
+                    inputMode="decimal"
                     value={guestForm.cash_out}
-                    onChange={(e) => setGuestForm((prev) => ({ ...prev, cash_out: e.target.value }))}
+                    onChange={(e) =>
+                      setGuestForm((prev) => ({
+                        ...prev,
+                        cash_out: e.target.value
+                      }))
+                    }
                   />
                 </div>
               </div>
@@ -1080,7 +1434,10 @@ export function GameSession({
 
       {isHost && (
         <div className="flex justify-end gap-2">
-          {(approved.length + guests.filter(g => g.cash_in !== null || g.cash_out !== null).length) >= 2 && (
+          {approved.length +
+            guests.filter((g) => g.cash_in !== null || g.cash_out !== null)
+              .length >=
+            2 && (
             <Button
               onClick={handleEndGame}
               disabled={ending}
@@ -1093,95 +1450,100 @@ export function GameSession({
         </div>
       )}
 
-      {/* Transfer Host Modal */}
-      {selectedPlayer && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center"
-          onClick={(e) => {
-            if (e.target === e.currentTarget) {
-              setSelectedPlayer(null)
-              setTransferConfirm(false)
-            }
-          }}
-        >
-          {/* Backdrop */}
-          <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+      <Dialog
+        open={!!selectedPlayer}
+        onOpenChange={(open) => {
+          if (!open && !transferring) {
+            setSelectedPlayer(null)
+            setTransferConfirm(false)
+          }
+        }}
+      >
+        <DialogContent className="max-w-sm">
+          {selectedPlayer && (
+            <>
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <Crown className="h-5 w-5 text-yellow-500" />
+                  Player Actions
+                </DialogTitle>
+                <DialogDescription>
+                  {playerName(selectedPlayer)}
+                </DialogDescription>
+              </DialogHeader>
 
-          {/* Modal */}
-          <div className="relative z-10 w-full max-w-sm mx-4 rounded-2xl border bg-background shadow-2xl p-6 space-y-5">
-            {/* Header */}
-            <div className="space-y-1">
-              <div className="flex items-center gap-2 text-lg font-semibold">
-                <Crown className="h-5 w-5 text-yellow-500" />
-                Player Actions
-              </div>
-              <p className="text-muted-foreground text-sm">
-                {selectedPlayer.display_name || selectedPlayer.venmo_handle || selectedPlayer.user_id.slice(0, 8)}
-              </p>
-            </div>
-
-            {/* Transfer Host section */}
-            <div className="rounded-xl border bg-muted/40 p-4 space-y-3">
-              <div className="flex items-center gap-2 font-medium text-sm">
-                <ArrowRightLeft className="h-4 w-4 text-muted-foreground" />
-                Transfer Host
-              </div>
-              <p className="text-xs text-muted-foreground">
-                This player will become the new host and gain full control of the game.
-                You will become a regular player.
-              </p>
-              {!transferConfirm ? (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="w-full"
-                  onClick={() => setTransferConfirm(true)}
-                >
-                  Make Host
-                </Button>
-              ) : (
-                <div className="space-y-2">
-                  <p className="text-xs text-yellow-400 font-medium">
-                    Are you sure? This cannot be undone without the new host&apos;s consent.
-                  </p>
-                  <div className="flex gap-2">
-                    <Button
-                      size="sm"
-                      variant="destructive"
-                      className="flex-1"
-                      disabled={transferring}
-                      onClick={() => handleTransferHost(selectedPlayer.user_id)}
-                    >
-                      {transferring ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : null}
-                      Confirm Transfer
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => setTransferConfirm(false)}
-                    >
-                      Cancel
-                    </Button>
-                  </div>
+              <div className="rounded-md border bg-muted/40 p-4 space-y-3">
+                <div className="flex items-center gap-2 font-medium text-sm">
+                  <ArrowRightLeft className="h-4 w-4 text-muted-foreground" />
+                  Transfer Host
                 </div>
-              )}
-            </div>
+                <p className="text-xs text-muted-foreground">
+                  This player will become the new host and gain full control of
+                  the game. You will become a regular player.
+                </p>
+                {!transferConfirm ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="w-full"
+                    aria-label={`Make ${playerName(selectedPlayer)} host`}
+                    onClick={() => setTransferConfirm(true)}
+                  >
+                    Make Host
+                  </Button>
+                ) : (
+                  <div className="space-y-2">
+                    <p
+                      className="text-xs text-yellow-700 font-medium dark:text-yellow-300"
+                      role="alert"
+                    >
+                      Are you sure? This cannot be undone without the new
+                      host&apos;s consent.
+                    </p>
+                    <div className="flex gap-2">
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        className="flex-1"
+                        disabled={transferring}
+                        aria-label={`Confirm transfer host to ${playerName(selectedPlayer)}`}
+                        onClick={() =>
+                          handleTransferHost(selectedPlayer.user_id)
+                        }
+                      >
+                        {transferring ? (
+                          <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                        ) : null}
+                        Confirm Transfer
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => setTransferConfirm(false)}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </div>
 
-            {/* Close */}
-            <Button
-              variant="ghost"
-              size="sm"
-              className="w-full text-zinc-500"
-              onClick={() => {
-                setSelectedPlayer(null)
-                setTransferConfirm(false)
-              }}
-            >
-              Close
-            </Button>
-          </div>
-        </div>
-      )}
+              {/* Close */}
+              <Button
+                variant="ghost"
+                size="sm"
+                className="w-full text-muted-foreground"
+                onClick={() => {
+                  setSelectedPlayer(null)
+                  setTransferConfirm(false)
+                }}
+              >
+                Close
+              </Button>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/components/leaderboard.tsx
+++ b/components/leaderboard.tsx
@@ -1,5 +1,11 @@
 import { createClient } from "@/lib/supabase/server"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "@/components/ui/card"
 import Link from "next/link"
 import { formatDollar } from "@/lib/utils"
 
@@ -16,24 +22,46 @@ export async function Leaderboard() {
     <Card id="leaderboard">
       <CardHeader>
         <CardTitle>Leaderboard</CardTitle>
-        <CardDescription>Top 3 by net profit (public profiles only)</CardDescription>
+        <CardDescription>
+          Top 3 by net profit (public profiles only)
+        </CardDescription>
       </CardHeader>
       <CardContent>
         {!profiles?.length ? (
-          <p className="text-muted-foreground text-sm">No public profiles yet.</p>
+          <p className="text-muted-foreground text-sm">
+            No public profiles yet.
+          </p>
         ) : (
           <ul className="space-y-2">
             {profiles.map((p, i) => (
-              <li key={p.id} className="flex items-center justify-between rounded border px-3 py-2">
-                <span className="font-medium">
-                  #{i + 1}{" "}
-                  <Link href={`/profile/${p.id}`} className="text-link hover:underline">
-                    {p.display_name || "Anonymous"}
-                  </Link>
-                </span>
-                <span className={p.net_profit >= 0 ? "text-green-600" : "text-red-600"}>
-                  {formatDollar(Number(p.net_profit))}
-                </span>
+              <li
+                key={p.id}
+                className="flex items-center justify-between rounded border px-3 py-2"
+              >
+                {(() => {
+                  const net = Number(p.net_profit)
+                  const netLabel =
+                    net > 0 ? "profit" : net < 0 ? "loss" : "even"
+                  return (
+                    <>
+                      <span className="font-medium">
+                        #{i + 1}{" "}
+                        <Link
+                          href={`/profile/${p.id}`}
+                          className="text-link hover:underline"
+                        >
+                          {p.display_name || "Anonymous"}
+                        </Link>
+                      </span>
+                      <span
+                        className={net >= 0 ? "text-green-600" : "text-red-600"}
+                      >
+                        {formatDollar(net)}{" "}
+                        <span className="sr-only">{netLabel}</span>
+                      </span>
+                    </>
+                  )
+                })()}
               </li>
             ))}
           </ul>

--- a/components/negative-chart.tsx
+++ b/components/negative-chart.tsx
@@ -8,6 +8,10 @@ import {
 import { Bar, BarChart, CartesianGrid, Cell, LabelList } from "recharts"
 import { formatDollar } from "@/lib/utils"
 
+function shortChartLabel(value: string) {
+  return value.length > 14 ? `${value.slice(0, 13)}…` : value
+}
+
 export function NegativeChart({ players }: { players: PlayerSchema[] }) {
   const chartConfig = {
     net: {
@@ -32,7 +36,11 @@ export function NegativeChart({ players }: { players: PlayerSchema[] }) {
                 : "var(--muted-foreground)"
         }))}
       >
-        <CartesianGrid vertical={false} stroke="hsl(var(--border))" strokeOpacity={0.3} />
+        <CartesianGrid
+          vertical={false}
+          stroke="var(--border)"
+          strokeOpacity={0.45}
+        />
         <ChartTooltip
           cursor={false}
           content={
@@ -43,18 +51,19 @@ export function NegativeChart({ players }: { players: PlayerSchema[] }) {
           }
         />
         <Bar dataKey="net">
-          <LabelList 
-            position="bottom" 
-            dataKey="displayName" 
-            fillOpacity={1} 
-            fill="hsl(var(--foreground))"
+          <LabelList
+            position="bottom"
+            dataKey="displayName"
+            fillOpacity={1}
+            fill="var(--foreground)"
             fontSize={12}
+            formatter={(val: string) => shortChartLabel(val)}
           />
           <LabelList
             position="top"
             dataKey="net"
             fillOpacity={1}
-            fill="hsl(var(--foreground))"
+            fill="var(--foreground)"
             fontSize={12}
             formatter={(val: number) => formatDollar(val)}
           />

--- a/components/net-profit-block.tsx
+++ b/components/net-profit-block.tsx
@@ -4,13 +4,17 @@ import { NetProfitGraph } from "./net-profit-graph"
 
 export function NetProfitBlock({ profile }: { profile: Profile }) {
   const net = Number(profile.net_profit)
+  const netLabel = net > 0 ? "profit" : net < 0 ? "loss" : "even"
 
   return (
     <div className="space-y-4">
       <div className="rounded-lg border bg-muted/50 p-4">
         <p className="text-muted-foreground text-sm">Net profit (all time)</p>
-        <p className={`text-2xl font-bold ${net >= 0 ? "text-green-600" : "text-red-600"}`}>
+        <p
+          className={`text-2xl font-bold ${net >= 0 ? "text-green-600" : "text-red-600"}`}
+        >
           {formatDollar(net)}
+          <span className="sr-only"> {netLabel}</span>
         </p>
       </div>
       <NetProfitGraph userId={profile.id} />

--- a/components/payout-stats-view.tsx
+++ b/components/payout-stats-view.tsx
@@ -6,12 +6,27 @@ import { SlippageInfo } from "./slippage-info"
 import { DonutCharts } from "./donut-chart"
 import { NegativeChart } from "./negative-chart"
 import { Card, CardContent } from "./ui/card"
+import { formatDollar } from "@/lib/utils"
 
 export function PayoutStatsView({ payout }: { payout: PayoutSchema }) {
-  const sorted = { ...payout, players: [...payout.players].sort((a, b) => a.name.localeCompare(b.name)) }
+  const sorted = {
+    ...payout,
+    players: [...payout.players].sort((a, b) => a.name.localeCompare(b.name))
+  }
 
   return (
     <div className="space-y-6">
+      <div className="sr-only">
+        <h3>Payout summary by player</h3>
+        <ul>
+          {sorted.players.map((player) => (
+            <li key={player.name}>
+              {player.displayName}: cash in {formatDollar(player.cashIn)}, cash
+              out {formatDollar(player.cashOut)}, net {formatDollar(player.net)}
+            </li>
+          ))}
+        </ul>
+      </div>
       {Math.abs(sorted.slippage) > 1e-9 && <SlippageInfo payout={sorted} />}
 
       <Card className="bg-card border-border">

--- a/components/player-summary.tsx
+++ b/components/player-summary.tsx
@@ -71,6 +71,8 @@ export function PlayerSummary({
   player: PlayerSchema
   slippage: number
 }) {
+  const netStatus =
+    player.net > 1e-9 ? "profit" : player.net < -1e-9 ? "loss" : "even"
   const transactionTypes = [
     {
       data: player.paidBy,
@@ -111,6 +113,7 @@ export function PlayerSummary({
           }`}
         >
           {formatDollar(player.net)}
+          <span className="sr-only"> {netStatus}</span>
         </CardAction>
       </CardHeader>
       {nonEmptyTransactions.length > 0 && (

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,142 @@
+"use client"
+
+import * as React from "react"
+import { X } from "lucide-react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-md border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-md opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:pointer-events-none"
+            aria-label="Close dialog"
+          >
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger
+}


### PR DESCRIPTION
## Summary
- add shared accessible dialog primitive and replace custom overlays in dashboard/game/metrics flows
- add skip-to-main targets, accessible names for icon buttons and amount inputs, and semantic row grouping
- improve chart dark-mode colors, chart accessibility layers, and screen-reader summaries while keeping visible UI minimal

## Verification
- npm run build

Note: npm test was run earlier and still fails in existing calcPayouts tests because expected objects omit the returned displayName field; this PR does not change calcPayouts behavior.