### PR TITLE
Add iOS host transfer and session-history deletion

### DIFF
--- a/ios/ChipCount/ChipCount/Services/GameService.swift
+++ b/ios/ChipCount/ChipCount/Services/GameService.swift
@@ -131,6 +131,12 @@ struct GameService {
       .execute()
   }
 
+  func transferHost(gameId: String, newHostId: String) async throws {
+    try await supabase
+      .rpc("transfer_host", params: TransferHostParams(pGameId: gameId, pNewHostId: newHostId))
+      .execute()
+  }
+
   func addGuest(gameId: String, name: String, cashIn: Double, cashOut: Double) async throws -> GameGuest {
     try await supabase
       .from("game_guests")
@@ -196,6 +202,15 @@ struct GameService {
       playerSnapshots: playerSnapshots,
       guestSnapshots: guestSnapshots
     )
+  }
+
+  func deleteSession(gameId: String, snapshottedAt: String) async throws {
+    try await supabase
+      .rpc(
+        "delete_session_at",
+        params: DeleteSessionParams(pGameId: gameId, pSnapshottedAt: snapshottedAt)
+      )
+      .execute()
   }
 
   func observeGame(gameId: String, onChange: @escaping @Sendable () async -> Void) async -> Task<Void, Never> {
@@ -355,6 +370,26 @@ private struct CloseSessionParams: Encodable {
   enum CodingKeys: String, CodingKey {
     case pGameId = "p_game_id"
     case pFinalStatus = "p_final_status"
+  }
+}
+
+private struct TransferHostParams: Encodable {
+  let pGameId: String
+  let pNewHostId: String
+
+  enum CodingKeys: String, CodingKey {
+    case pGameId = "p_game_id"
+    case pNewHostId = "p_new_host_id"
+  }
+}
+
+private struct DeleteSessionParams: Encodable {
+  let pGameId: String
+  let pSnapshottedAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case pGameId = "p_game_id"
+    case pSnapshottedAt = "p_snapshotted_at"
   }
 }
 

--- a/ios/ChipCount/ChipCount/Views/GameRoomView.swift
+++ b/ios/ChipCount/ChipCount/Views/GameRoomView.swift
@@ -12,6 +12,7 @@ struct GameRoomView: View {
   @State private var guestName = ""
   @State private var guestCashIn = 0.0
   @State private var guestCashOut = 0.0
+  @State private var transferCandidate: GamePlayer?
   @State private var realtimeTask: Task<Void, Never>?
 
   let gameId: String
@@ -65,6 +66,20 @@ struct GameRoomView: View {
         Task { await load() }
       }
     }
+    .confirmationDialog(
+      "Transfer Host?",
+      isPresented: Binding(
+        get: { transferCandidate != nil },
+        set: { if !$0 { transferCandidate = nil } }
+      ),
+      presenting: transferCandidate
+    ) { player in
+      Button("Transfer to \(player.displayName ?? String(player.userId.prefix(8)))", role: .destructive) {
+        Task { await transferHost(to: player) }
+      }
+    } message: { player in
+      Text("\(player.displayName ?? String(player.userId.prefix(8))) will immediately control this table.")
+    }
   }
 
   @ViewBuilder
@@ -94,7 +109,7 @@ struct GameRoomView: View {
         }
 
         NavigationLink {
-          MetricsView(gameId: snapshot.game.id)
+          MetricsView(gameId: snapshot.game.id, isHost: isHost(snapshot))
         } label: {
           Label("Metrics", systemImage: "chart.line.uptrend.xyaxis")
         }
@@ -254,6 +269,23 @@ struct GameRoomView: View {
           Label("End Table", systemImage: "xmark.circle")
         }
       }
+
+      let transferCandidates = snapshot.approvedPlayers.filter { $0.userId != snapshot.game.hostId }
+      if !transferCandidates.isEmpty {
+        Section {
+          ForEach(transferCandidates) { player in
+            Button {
+              transferCandidate = player
+            } label: {
+              Label(player.displayName ?? String(player.userId.prefix(8)), systemImage: "crown")
+            }
+          }
+        } header: {
+          Text("Transfer Host")
+        } footer: {
+          Text("The selected player immediately becomes the table host.")
+        }
+      }
     }
   }
 
@@ -372,6 +404,16 @@ struct GameRoomView: View {
   private func endTable() async {
     do {
       try await service.endTable(gameId: gameId)
+      await load()
+    } catch {
+      errorMessage = error.localizedDescription
+    }
+  }
+
+  private func transferHost(to player: GamePlayer) async {
+    do {
+      try await service.transferHost(gameId: gameId, newHostId: player.userId)
+      transferCandidate = nil
       await load()
     } catch {
       errorMessage = error.localizedDescription

--- a/ios/ChipCount/ChipCount/Views/MetricsView.swift
+++ b/ios/ChipCount/ChipCount/Views/MetricsView.swift
@@ -7,8 +7,10 @@ struct MetricsView: View {
   @State private var metrics: GameMetrics?
   @State private var errorMessage: String?
   @State private var isLoading = false
+  @State private var deleteCandidate: String?
 
   let gameId: String
+  let isHost: Bool
 
   var body: some View {
     List {
@@ -39,17 +41,31 @@ struct MetricsView: View {
 
         Section("Table History") {
           ForEach(metrics.sessionTimestamps, id: \.self) { timestamp in
-            VStack(alignment: .leading, spacing: 6) {
-              Text(timestamp.formattedSnapshotDate)
-                .font(.headline)
-              let players = metrics.playerSnapshots.filter { $0.snapshottedAt == timestamp }
-              let guests = metrics.guestSnapshots.filter { $0.snapshottedAt == timestamp }
-              Text("\(players.count) players, \(guests.count) guests")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-              Text("Total net \(sessionTotal(players: players, guests: guests).chipCountCurrency)")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            HStack {
+              VStack(alignment: .leading, spacing: 6) {
+                Text(timestamp.formattedSnapshotDate)
+                  .font(.headline)
+                let players = metrics.playerSnapshots.filter { $0.snapshottedAt == timestamp }
+                let guests = metrics.guestSnapshots.filter { $0.snapshottedAt == timestamp }
+                Text("\(players.count) players, \(guests.count) guests")
+                  .font(.caption)
+                  .foregroundStyle(.secondary)
+                Text("Total net \(sessionTotal(players: players, guests: guests).chipCountCurrency)")
+                  .font(.caption)
+                  .foregroundStyle(.secondary)
+              }
+
+              Spacer()
+
+              if isHost {
+                Button(role: .destructive) {
+                  deleteCandidate = timestamp
+                } label: {
+                  Image(systemName: "trash")
+                }
+                .buttonStyle(.borderless)
+                .accessibilityLabel("Delete session")
+              }
             }
           }
         }
@@ -71,6 +87,20 @@ struct MetricsView: View {
     .task {
       await load()
     }
+    .confirmationDialog(
+      "Delete Session History?",
+      isPresented: Binding(
+        get: { deleteCandidate != nil },
+        set: { if !$0 { deleteCandidate = nil } }
+      ),
+      presenting: deleteCandidate
+    ) { timestamp in
+      Button("Delete Session", role: .destructive) {
+        Task { await deleteSession(at: timestamp) }
+      }
+    } message: { timestamp in
+      Text("This removes the \(timestamp.formattedSnapshotDate) snapshot and reverses its profile profit changes.")
+    }
   }
 
   private func load() async {
@@ -87,6 +117,16 @@ struct MetricsView: View {
 
   private func sessionTotal(players: [SessionSnapshot], guests: [GuestSessionSnapshot]) -> Double {
     players.reduce(0) { $0 + $1.sessionNet } + guests.reduce(0) { $0 + $1.sessionNet }
+  }
+
+  private func deleteSession(at timestamp: String) async {
+    do {
+      try await service.deleteSession(gameId: gameId, snapshottedAt: timestamp)
+      deleteCandidate = nil
+      await load()
+    } catch {
+      errorMessage = error.localizedDescription
+    }
   }
 }
 

--- a/ios/ChipCount/README.md
+++ b/ios/ChipCount/README.md
@@ -35,11 +35,13 @@ Native SwiftUI app scaffold for ChipCount.
 
 ## Backend dependency
 
-Run migrations through `supabase/migrations/00017_standardize_host_session_rpcs.sql` before using the app. The iOS client calls:
+Run migrations through `supabase/migrations/00018_transfer_host_rpc.sql` before using the app. The iOS client calls:
 
 - `close_session_with_debts`
 - `reopen_session`
 - `end_table`
+- `delete_session_at`
+- `transfer_host`
 
 ## Local test
 

--- a/supabase/migrations/00018_transfer_host_rpc.sql
+++ b/supabase/migrations/00018_transfer_host_rpc.sql
@@ -1,0 +1,49 @@
+-- Host-only transfer to an approved player.
+create or replace function public.transfer_host(
+  p_game_id uuid,
+  p_new_host_id uuid
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_host_id uuid;
+  v_new_host_status public.game_player_status;
+begin
+  select host_id
+    into v_host_id
+  from public.games
+  where id = p_game_id
+  for update;
+
+  if v_host_id is null then
+    raise exception 'Game not found';
+  end if;
+
+  if v_host_id != auth.uid() then
+    raise exception 'Not the host of this game';
+  end if;
+
+  if p_new_host_id = v_host_id then
+    raise exception 'Player is already the host';
+  end if;
+
+  select status
+    into v_new_host_status
+  from public.game_players
+  where game_id = p_game_id
+    and user_id = p_new_host_id;
+
+  if v_new_host_status is distinct from 'approved' then
+    raise exception 'New host must be an approved player';
+  end if;
+
+  update public.games
+  set host_id = p_new_host_id
+  where id = p_game_id;
+end;
+$$;
+
+grant execute on function public.transfer_host(uuid, uuid) to authenticated;


### PR DESCRIPTION
## Summary
- add an iOS host-transfer flow with confirmation for approved players
- add a host-only `transfer_host` Supabase RPC
- add host-only session-history deletion from the iOS metrics view using the existing `delete_session_at` RPC
- update the iOS setup note to require migrations through `00018`

## Verification
- `xcodebuild -project ios/ChipCount/ChipCount.xcodeproj -scheme ChipCount -destination 'generic/platform=iOS Simulator' build`
- `HOME=/private/tmp/chipcount-home CLANG_MODULE_CACHE_PATH=/private/tmp/chipcount-module-cache swift test --scratch-path /private/tmp/chipcount-swift-build`
- `git diff --check`

## Notes
- auth files were intentionally left untouched
- apply `supabase/migrations/00018_transfer_host_rpc.sql` before testing host transfer against Supabase