### PR TITLE
Harden session history deletion and guest amount editing

### DIFF
--- a/components/game-session.tsx
+++ b/components/game-session.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation"
 import { createClient } from "@/lib/supabase/client"
 import { setGameStatus, kickPlayer, requestRejoin, transferHost, updateRequestedAmounts } from "@/lib/actions"
 import { calcPayouts } from "@/lib/utils"
+import { parseCashInput, toGuestAmountPatch } from "@/lib/guest-amounts"
 import type { GameSchema } from "@/lib/schemas"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -39,19 +40,10 @@ type GuestPlayer = {
   cash_out: number | null
 }
 
-// Helper function to parse cash input values, handling "zero" conversion
-function parseCashInput(value: string): number | null {
-  if (value === "") return null
-  if (value.toLowerCase() === "zero") return 0
-  const parsed = parseFloat(value)
-  return isNaN(parsed) ? null : parsed
-}
-
 export function GameSession({
   game,
   initialPlayers,
   currentUserId,
-  isHost: _initialIsHost,
   baseUrl
 }: {
   game: Game
@@ -161,18 +153,33 @@ export function GameSession({
   }
 
   async function updateGuestDb(guestId: string, updates: Partial<Pick<GuestPlayer, "cash_in" | "cash_out">>) {
+    if (isClosed) return
     setGuests((prev) => prev.map((g) => (g.id === guestId ? { ...g, ...updates } : g)))
     const supabase = createClient()
-    const patch: Record<string, number> = {}
-    if (updates.cash_in !== undefined) patch.cash_in = updates.cash_in ?? 0
-    if (updates.cash_out !== undefined) patch.cash_out = updates.cash_out ?? 0
-    await supabase.from("game_guests").update(patch).eq("id", guestId)
+    const { error } = await supabase
+      .from("game_guests")
+      .update(toGuestAmountPatch(updates))
+      .eq("id", guestId)
+      .eq("game_id", game.id)
+    if (error) {
+      toast.error("Failed to update guest amount")
+      await fetchAll()
+    }
   }
 
   async function removeGuest(guestId: string) {
+    if (isClosed) return
     setGuests((prev) => prev.filter((g) => g.id !== guestId))
     const supabase = createClient()
-    await supabase.from("game_guests").delete().eq("id", guestId)
+    const { error } = await supabase
+      .from("game_guests")
+      .delete()
+      .eq("id", guestId)
+      .eq("game_id", game.id)
+    if (error) {
+      toast.error("Failed to remove guest")
+      await fetchAll()
+    }
   }
 
   async function handleKick(userId: string) {
@@ -182,7 +189,7 @@ export function GameSession({
     try {
       await kickPlayer(game.id, userId)
       toast.success("Player removed")
-    } catch (err) {
+    } catch {
       toast.error("Failed to remove player")
       // Revert by refetching
       fetchAll()
@@ -305,9 +312,6 @@ export function GameSession({
       })
     }
   }
-
-  // Keep fetchPlayers as alias for backwards compat with realtime callbacks
-  const fetchPlayers = fetchAll
 
   useEffect(() => {
     const supabase = createClient()
@@ -1005,7 +1009,7 @@ export function GameSession({
                       onBlur={(e) => {
                         const v = parseCashInput(e.target.value)
                         setFieldEditing(`guest-${guest.id}-cash_in`, false)
-                        updateGuestDb(guest.id, { cash_in: v })
+                        void updateGuestDb(guest.id, { cash_in: v })
                       }}
                       disabled={isClosed}
                     />
@@ -1021,14 +1025,15 @@ export function GameSession({
                       onBlur={(e) => {
                         const v = parseCashInput(e.target.value)
                         setFieldEditing(`guest-${guest.id}-cash_out`, false)
-                        updateGuestDb(guest.id, { cash_out: v })
+                        void updateGuestDb(guest.id, { cash_out: v })
                       }}
                       disabled={isClosed}
                     />
                     <button
                       className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:bg-red-500/10 hover:text-red-500 transition-colors"
                       title="Remove guest"
-                      onClick={() => removeGuest(guest.id)}
+                      onClick={() => void removeGuest(guest.id)}
+                      disabled={isClosed}
                     >
                       <X className="h-3.5 w-3.5" />
                     </button>

--- a/lib/guest-amounts.test.ts
+++ b/lib/guest-amounts.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { parseCashInput, toGuestAmountPatch } from "./guest-amounts";
+
+describe("parseCashInput", () => {
+  it("keeps an empty input editable", () => {
+    expect(parseCashInput("")).toBeNull();
+  });
+
+  it("accepts numeric values and the zero shortcut", () => {
+    expect(parseCashInput("12.50")).toBe(12.5);
+    expect(parseCashInput("zero")).toBe(0);
+    expect(parseCashInput("ZERO")).toBe(0);
+  });
+
+  it("returns null for invalid values", () => {
+    expect(parseCashInput("not-a-number")).toBeNull();
+  });
+});
+
+describe("toGuestAmountPatch", () => {
+  it("updates only the edited guest amount", () => {
+    expect(toGuestAmountPatch({ cash_in: 25 })).toEqual({ cash_in: 25 });
+    expect(toGuestAmountPatch({ cash_out: 40 })).toEqual({ cash_out: 40 });
+  });
+
+  it("persists a cleared guest amount as zero", () => {
+    expect(toGuestAmountPatch({ cash_in: null })).toEqual({ cash_in: 0 });
+    expect(toGuestAmountPatch({ cash_out: null })).toEqual({ cash_out: 0 });
+  });
+});

--- a/lib/guest-amounts.ts
+++ b/lib/guest-amounts.ts
@@ -1,0 +1,21 @@
+export type GuestAmounts = {
+  cash_in: number | null;
+  cash_out: number | null;
+};
+
+// Keep empty inputs editable in the UI while persisting them as zero.
+export function parseCashInput(value: string): number | null {
+  if (value === "") return null;
+  if (value.toLowerCase() === "zero") return 0;
+  const parsed = parseFloat(value);
+  return isNaN(parsed) ? null : parsed;
+}
+
+export function toGuestAmountPatch(
+  updates: Partial<GuestAmounts>,
+): Partial<Record<keyof GuestAmounts, number>> {
+  const patch: Partial<Record<keyof GuestAmounts, number>> = {};
+  if (updates.cash_in !== undefined) patch.cash_in = updates.cash_in ?? 0;
+  if (updates.cash_out !== undefined) patch.cash_out = updates.cash_out ?? 0;
+  return patch;
+}

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -18,6 +18,7 @@ describe("calcPayouts", () => {
       players: [
         {
           name: "Bob",
+          displayName: "Bob",
           cashIn: 100,
           cashOut: 0,
           net: -100,
@@ -26,6 +27,7 @@ describe("calcPayouts", () => {
         },
         {
           name: "Alice",
+          displayName: "Alice",
           cashIn: 100,
           cashOut: 200,
           net: 100,
@@ -105,6 +107,7 @@ describe("calcPayouts", () => {
       players: [
         {
           name: "Alice",
+          displayName: "Alice",
           cashIn: 100,
           cashOut: 150,
           net: 50,
@@ -113,6 +116,7 @@ describe("calcPayouts", () => {
         },
         {
           name: "Bob",
+          displayName: "Bob",
           cashIn: 100,
           cashOut: 100,
           net: 0,
@@ -121,6 +125,7 @@ describe("calcPayouts", () => {
         },
         {
           name: "Charlie",
+          displayName: "Charlie",
           cashIn: 100,
           cashOut: 50,
           net: -50,

--- a/supabase/migrations/00016_delete_session_at.sql
+++ b/supabase/migrations/00016_delete_session_at.sql
@@ -16,7 +16,7 @@ declare
   v_guest_rows int;
 begin
   select host_id into v_host_id from public.games where id = p_game_id for update;
-  if v_host_id is null or v_host_id != auth.uid() then
+  if v_host_id is distinct from auth.uid() then
     raise exception 'Not the host of this game';
   end if;
 
@@ -50,4 +50,5 @@ begin
 end;
 $$;
 
+revoke all on function public.delete_session_at(uuid, timestamptz) from public;
 grant execute on function public.delete_session_at(uuid, timestamptz) to authenticated;

--- a/supabase/migrations/00016_delete_session_at.test.ts
+++ b/supabase/migrations/00016_delete_session_at.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  new URL("./00016_delete_session_at.sql", import.meta.url),
+  "utf8",
+);
+
+describe("delete_session_at migration", () => {
+  it("uses a null-safe host check", () => {
+    expect(migration).toContain("v_host_id is distinct from auth.uid()");
+  });
+
+  it("does not expose the security-definer function to anonymous callers", () => {
+    expect(migration).toContain(
+      "revoke all on function public.delete_session_at(uuid, timestamptz) from public;",
+    );
+    expect(migration).toContain(
+      "grant execute on function public.delete_session_at(uuid, timestamptz) to authenticated;",
+    );
+  });
+
+  it("rolls back profile totals and deletes registered and guest snapshots", () => {
+    expect(migration).toContain(
+      "set net_profit = net_profit - rec.session_net",
+    );
+    expect(migration).toContain("delete from public.session_snapshots");
+    expect(migration).toContain("delete from public.guest_session_snapshots");
+  });
+});

--- a/supabase/tests/delete_session_at.test.sql
+++ b/supabase/tests/delete_session_at.test.sql
@@ -1,0 +1,161 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+
+select plan(7);
+
+insert into auth.users (id, email)
+values
+  ('00000000-0000-0000-0000-000000000001', 'host@example.com'),
+  ('00000000-0000-0000-0000-000000000002', 'player@example.com');
+
+insert into public.games (id, host_id, description)
+values (
+  '10000000-0000-0000-0000-000000000001',
+  '00000000-0000-0000-0000-000000000001',
+  'Deletion test'
+);
+
+insert into public.game_players (game_id, user_id, status)
+values
+  (
+    '10000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000001',
+    'approved'
+  ),
+  (
+    '10000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000002',
+    'approved'
+  );
+
+update public.profiles
+set net_profit = case
+  when id = '00000000-0000-0000-0000-000000000001' then 30
+  else -30
+end
+where id in (
+  '00000000-0000-0000-0000-000000000001',
+  '00000000-0000-0000-0000-000000000002'
+);
+
+insert into public.session_snapshots (
+  game_id,
+  user_id,
+  cash_in,
+  cash_out,
+  session_net,
+  snapshotted_at
+)
+values
+  (
+    '10000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000001',
+    20,
+    50,
+    30,
+    '2026-05-30 12:00:00+00'
+  ),
+  (
+    '10000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000002',
+    50,
+    20,
+    -30,
+    '2026-05-30 12:00:00+00'
+  );
+
+insert into public.guest_session_snapshots (
+  game_id,
+  guest_name,
+  cash_in,
+  cash_out,
+  session_net,
+  snapshotted_at
+)
+values (
+  '10000000-0000-0000-0000-000000000001',
+  'Guest',
+  10,
+  10,
+  0,
+  '2026-05-30 12:00:00+00'
+);
+
+set local role authenticated;
+select set_config(
+  'request.jwt.claim.sub',
+  '00000000-0000-0000-0000-000000000001',
+  true
+);
+
+select lives_ok(
+  $$ select public.delete_session_at(
+    '10000000-0000-0000-0000-000000000001',
+    '2026-05-30 12:00:00+00'
+  ) $$,
+  'the host can delete a session'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from public.session_snapshots
+    where game_id = '10000000-0000-0000-0000-000000000001'
+  ),
+  0,
+  'registered-player snapshots are deleted'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from public.guest_session_snapshots
+    where game_id = '10000000-0000-0000-0000-000000000001'
+  ),
+  0,
+  'guest snapshots are deleted'
+);
+
+select is(
+  (
+    select net_profit
+    from public.profiles
+    where id = '00000000-0000-0000-0000-000000000001'
+  ),
+  0::numeric,
+  'the host profit is rolled back'
+);
+
+select is(
+  (
+    select net_profit
+    from public.profiles
+    where id = '00000000-0000-0000-0000-000000000002'
+  ),
+  0::numeric,
+  'the player profit is rolled back'
+);
+
+select throws_ok(
+  $$ select public.delete_session_at(
+    '10000000-0000-0000-0000-000000000001',
+    '2026-05-30 12:00:00+00'
+  ) $$,
+  'No session found for this timestamp',
+  'a deleted session cannot be deleted twice'
+);
+
+set local role anon;
+
+select throws_ok(
+  $$ select public.delete_session_at(
+    '10000000-0000-0000-0000-000000000001',
+    '2026-05-30 12:00:00+00'
+  ) $$,
+  'permission denied for function delete_session_at',
+  'anonymous callers cannot execute the deletion RPC'
+);
+
+select * from finish();
+rollback;

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    globals: true,
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,0 @@
-import { defineConfig } from "vitest/config"
-import tsconfigPaths from "vite-tsconfig-paths"
-
-export default defineConfig({
-  plugins: [tsconfigPaths()],
-  test: {
-    globals: true
-  }
-})


### PR DESCRIPTION
## Summary
- secure the session-history deletion RPC with a null-safe host check and authenticated-only execution
- add regression coverage for deleting snapshots and rolling back profile totals
- persist guest amount edits after creation with scoped updates and UI recovery when Supabase writes fail
- prevent guest removal while a session is closed
- rename the Vitest config to `.mts` so the existing suite runs with Vite ESM

## Verification
- `npm test` (19 passing)
- `npx tsc --noEmit`
- `npx eslint components/game-session.tsx lib/guest-amounts.ts lib/guest-amounts.test.ts lib/utils.test.ts supabase/migrations/00016_delete_session_at.test.ts vitest.config.mts`
- `npm run build`
- `git diff --check`

## Note
- added a pgTAP SQL regression test at `supabase/tests/delete_session_at.test.sql`
- the Supabase CLI is not installed in the local workspace, so the pgTAP file could not be executed locally