### PR TITLE
fix(ios): force lowercase UUID for current user ID matching + guest prepopulation

### DIFF
--- a/ios/ChipCount/ChipCount/Services/AuthSessionStore.swift
+++ b/ios/ChipCount/ChipCount/Services/AuthSessionStore.swift
@@ -25,7 +25,7 @@ final class AuthSessionStore: ObservableObject {
 
     do {
       let user = try await supabase.auth.user()
-      currentUser = AuthenticatedUser(id: String(describing: user.id), email: user.email)
+      currentUser = AuthenticatedUser(id: user.id.uuidString.lowercased(), email: user.email)
       try await refreshProfile(displayNameFallback: nil)
     } catch {
       currentUser = nil
@@ -38,7 +38,7 @@ final class AuthSessionStore: ObservableObject {
     errorMessage = nil
     do {
       let session = try await supabase.auth.signIn(email: email, password: password)
-      currentUser = AuthenticatedUser(id: String(describing: session.user.id), email: session.user.email)
+      currentUser = AuthenticatedUser(id: session.user.id.uuidString.lowercased(), email: session.user.email)
       try await refreshProfile(displayNameFallback: nil)
     } catch {
       errorMessage = error.localizedDescription
@@ -118,7 +118,7 @@ final class AuthSessionStore: ObservableObject {
       let fullName = [credential.fullName?.givenName, credential.fullName?.familyName]
         .compactMap { $0 }
         .joined(separator: " ")
-      currentUser = AuthenticatedUser(id: String(describing: session.user.id), email: session.user.email)
+      currentUser = AuthenticatedUser(id: session.user.id.uuidString.lowercased(), email: session.user.email)
       try await refreshProfile(displayNameFallback: fullName.isEmpty ? nil : fullName)
     } catch {
       errorMessage = error.localizedDescription

--- a/ios/ChipCount/ChipCount/Services/GameService.swift
+++ b/ios/ChipCount/ChipCount/Services/GameService.swift
@@ -21,7 +21,7 @@ struct GameService {
     }
   }
 
-  func createTable(hostId: String, description: String?) async throws -> Game {
+  func createTable(hostId: String, description: String?, guests: [String] = []) async throws -> Game {
     let game: Game = try await supabase
       .from("games")
       .insert(NewGame(hostId: hostId, description: description?.nilIfBlank))
@@ -34,6 +34,14 @@ struct GameService {
       .from("game_players")
       .insert(NewGamePlayer(gameId: game.id, userId: hostId, status: .approved, requestedCashIn: 0, requestedCashOut: 0))
       .execute()
+
+    if !guests.isEmpty {
+      let newGuests = guests.map { NewGuest(gameId: game.id, name: $0, cashIn: 0, cashOut: 0) }
+      try? await supabase
+        .from("game_guests")
+        .insert(newGuests)
+        .execute()
+    }
 
     return game
   }

--- a/ios/ChipCount/ChipCount/Views/TablesView.swift
+++ b/ios/ChipCount/ChipCount/Views/TablesView.swift
@@ -65,8 +65,8 @@ struct TablesView: View {
       await loadTables()
     }
     .sheet(isPresented: $showingCreate) {
-      CreateTableSheet { name in
-        await createTable(name: name)
+      CreateTableSheet { name, guests in
+        await createTable(name: name, guests: guests)
       }
     }
     .sheet(isPresented: $showingJoin) {
@@ -92,11 +92,11 @@ struct TablesView: View {
     }
   }
 
-  private func createTable(name: String?) async {
+  private func createTable(name: String?, guests: [String]) async {
     guard let userId = authStore.currentUser?.id else { return }
 
     do {
-      let game = try await service.createTable(hostId: userId, description: name)
+      let game = try await service.createTable(hostId: userId, description: name, guests: guests)
       showingCreate = false
       await loadTables()
       selectedGame = game
@@ -168,8 +168,10 @@ private struct TableRow: View {
 private struct CreateTableSheet: View {
   @Environment(\.dismiss) private var dismiss
   @State private var tableName = ""
+  @State private var guestName = ""
+  @State private var guests: [String] = []
   @State private var isSubmitting = false
-  let onCreate: (String?) async -> Void
+  let onCreate: (String?, [String]) async -> Void
 
   var body: some View {
     NavigationStack {
@@ -181,6 +183,38 @@ private struct CreateTableSheet: View {
         } footer: {
           Text("Optional. Players will see this before joining.")
         }
+        
+        Section {
+          HStack {
+            TextField("Guest name", text: $guestName)
+            Button {
+              let trimmed = guestName.trimmingCharacters(in: .whitespacesAndNewlines)
+              if !trimmed.isEmpty, !guests.contains(where: { $0.caseInsensitiveCompare(trimmed) == .orderedSame }) {
+                guests.append(trimmed)
+                guestName = ""
+              }
+            } label: {
+              Image(systemName: "person.badge.plus")
+            }
+            .disabled(guestName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+          }
+          
+          ForEach(guests, id: \.self) { guest in
+            HStack {
+              Text(guest)
+              Spacer()
+              Button(role: .destructive) {
+                guests.removeAll { $0 == guest }
+              } label: {
+                Image(systemName: "trash")
+              }
+            }
+          }
+        } header: {
+          Text("Guests")
+        } footer: {
+          Text("Optional. Pre-add guests who don't have accounts.")
+        }
       }
       .navigationTitle("New Table")
       .toolbar {
@@ -191,7 +225,7 @@ private struct CreateTableSheet: View {
           Button("Create") {
             Task {
               isSubmitting = true
-              await onCreate(tableName)
+              await onCreate(tableName, guests)
               isSubmitting = false
             }
           }


### PR DESCRIPTION
## Summary
Fixes a bug in the iOS app where the table creator was incorrectly labeled as a **Player** instead of **Host** due to UUID case-sensitivity in Swift, and adds the guest pre-population feature to the iOS app.

## Changes
1. **Fix Host Recognition:**
   - In Swift, `String(describing: UUID())` returns an uppercase string (e.g. `E621...`), but Supabase returns lowercase UUID strings.
   - Updated `AuthSessionStore` to use `.uuidString.lowercased()` so string comparisons against database IDs (like `game.hostId == currentUserId`) match correctly.
2. **iOS Create Table Guests:**
   - Replicated the web app's new guest pre-population feature in the native iOS app.
   - Added an optional Guests section in `CreateTableSheet` (accessible when you tap Create Table).
   - Guests are added via a text field and plus button, and batch inserted immediately into `game_guests` when the table is created.