### PR TITLE
fix(ios): resolve guest saving and close session RPC bugs

### DIFF
--- a/ios/ChipCount/ChipCount/Services/GameService.swift
+++ b/ios/ChipCount/ChipCount/Services/GameService.swift
@@ -145,14 +145,11 @@ struct GameService {
       .execute()
   }
 
-  func addGuest(gameId: String, name: String, cashIn: Double, cashOut: Double) async throws -> GameGuest {
+  func addGuest(gameId: String, name: String, cashIn: Double, cashOut: Double) async throws {
     try await supabase
       .from("game_guests")
       .insert(NewGuest(gameId: gameId, name: name, cashIn: cashIn, cashOut: cashOut))
-      .select("id, game_id, name, cash_in, cash_out")
-      .single()
       .execute()
-      .value
   }
 
   func updateGuest(_ guest: GameGuest) async throws {
@@ -172,9 +169,10 @@ struct GameService {
   }
 
   func closeSession(gameId: String) async throws {
-    try await supabase
+    let _: String = try await supabase
       .rpc("close_session_with_debts", params: CloseSessionParams(pGameId: gameId, pFinalStatus: "closed"))
       .execute()
+      .value
   }
 
   func reopenSession(gameId: String) async throws {

--- a/ios/ChipCount/ChipCount/Views/GameRoomView.swift
+++ b/ios/ChipCount/ChipCount/Views/GameRoomView.swift
@@ -359,7 +359,7 @@ struct GameRoomView: View {
 
   private func addGuest() async {
     do {
-      _ = try await service.addGuest(
+      try await service.addGuest(
         gameId: gameId,
         name: guestName,
         cashIn: guestCashIn,

--- a/ios/ChipCount/ChipCount/Views/TablesView.swift
+++ b/ios/ChipCount/ChipCount/Views/TablesView.swift
@@ -225,7 +225,12 @@ private struct CreateTableSheet: View {
           Button("Create") {
             Task {
               isSubmitting = true
-              await onCreate(tableName, guests)
+              var finalGuests = guests
+              let trimmed = guestName.trimmingCharacters(in: .whitespacesAndNewlines)
+              if !trimmed.isEmpty, !finalGuests.contains(where: { $0.caseInsensitiveCompare(trimmed) == .orderedSame }) {
+                finalGuests.append(trimmed)
+              }
+              await onCreate(tableName, finalGuests)
               isSubmitting = false
             }
           }


### PR DESCRIPTION
## Summary
Fixes two bugs reported in the iOS app:
1. **Adding a Guest:** Fixed an issue where creating a new table with a guest left in the text field (but without hitting the '+' button) silently ignored the guest. Fixed another decoding issue where adding a guest in the active session failed silently because the client tried to decode the inserted guest but the DB response didn't match the `Codable` expectations perfectly.
2. **Close Session Button:** Fixed the Close Session button silently failing. The RPC `close_session_with_debts` returns a `timestamptz`, but the Swift client's `.execute()` attempted to decode a `Void` response. It now decodes the timestamp string correctly so the request completes without throwing.