### PR TITLE
fix(ios): sequential guest insert on table create

### DIFF
--- a/ios/ChipCount/ChipCount/Services/GameService.swift
+++ b/ios/ChipCount/ChipCount/Services/GameService.swift
@@ -36,11 +36,13 @@ struct GameService {
       .execute()
 
     if !guests.isEmpty {
-      let newGuests = guests.map { NewGuest(gameId: game.id, name: $0, cashIn: 0, cashOut: 0) }
-      try? await supabase
-        .from("game_guests")
-        .insert(newGuests)
-        .execute()
+      for guestName in guests {
+        let newGuest = NewGuest(gameId: game.id, name: guestName, cashIn: 0, cashOut: 0)
+        try await supabase
+          .from("game_guests")
+          .insert(newGuest)
+          .execute()
+      }
     }
 
     return game


### PR DESCRIPTION
Fixes a silent failure where the Supabase Swift client was silently dropping the array-based bulk insert during table creation.