### PR TITLE
Fix welcome greeting first name

### DIFF
--- a/ChipCount/Views/TablesView.swift
+++ b/ChipCount/Views/TablesView.swift
@@ -16,11 +16,12 @@ struct TablesView: View {
     List {
       Section {
         VStack(alignment: .leading, spacing: 4) {
-          if let name = authStore.profile?.displayName, !name.isEmpty {
-            Text("welcom welcome, \(name)")
+          if let name = authStore.profile?.displayName,
+             let firstName = name.split(whereSeparator: \.isWhitespace).first {
+            Text("Welcome, \(firstName)")
               .font(.largeTitle.bold())
           } else {
-            Text("welcom welcome")
+            Text("Welcome")
               .font(.largeTitle.bold())
           }
         }


### PR DESCRIPTION
## Summary
- replace the duplicated typo in the tables welcome greeting
- display only the user's first name when a profile display name is available
- fall back to `Welcome` when no display name is set

## Verification
- `swift test`
- `xcodebuild -project ChipCount.xcodeproj -scheme ChipCount -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build`