### PR TITLE
Spectator mode, quick games, and guest UI polish

### DIFF
--- a/app/invite/[code]/page.tsx
+++ b/app/invite/[code]/page.tsx
@@ -43,52 +43,45 @@ export default async function InvitePage({
 
   const shortCode = code.trim().toLowerCase()
 
-  if (!user) {
-    const { data: spectatorData, error } = await supabase.rpc(
-      "get_spectator_game",
-      { p_short_code: shortCode }
-    )
+  if (user) {
+    await ensureProfile(supabase, user.id, user.email ?? null)
 
-    if (error || !spectatorData) {
-      notFound()
+    const { data: game } = await supabase
+      .from("games")
+      .select("id")
+      .eq("short_code", shortCode)
+      .maybeSingle()
+
+    if (game) {
+      const { data: existingParticipation } = await supabase
+        .from("game_players")
+        .select("status")
+        .eq("game_id", game.id)
+        .eq("user_id", user.id)
+        .maybeSingle()
+
+      if (existingParticipation) {
+        redirect(`/game/${game.id}`)
+      }
     }
-
-    return (
-      <main id="main-content" tabIndex={-1}>
-        <SpectatorGameView
-          shortCode={shortCode}
-          initialData={spectatorData as SpectatorGameData}
-        />
-      </main>
-    )
   }
 
-  await ensureProfile(supabase, user.id, user.email ?? null)
+  const { data: spectatorData, error } = await supabase.rpc(
+    "get_spectator_game",
+    { p_short_code: shortCode }
+  )
 
-  const { data: game, error: gameError } = await supabase
-    .from("games")
-    .select("id, status")
-    .eq("short_code", shortCode)
-    .single()
-
-  if (gameError || !game) {
+  if (error || !spectatorData) {
     notFound()
   }
 
-  const { data: existingParticipation } = await supabase
-    .from("game_players")
-    .select("status")
-    .eq("game_id", game.id)
-    .eq("user_id", user.id)
-    .maybeSingle()
-
-  if (existingParticipation) {
-    redirect(`/game/${game.id}`)
-  }
-
-  if (game.status !== "active") {
-    notFound()
-  }
-
-  redirect(`/invite/${code}/join`)
+  return (
+    <main id="main-content" tabIndex={-1}>
+      <SpectatorGameView
+        shortCode={shortCode}
+        initialData={spectatorData as SpectatorGameData}
+        isAuthenticated={!!user}
+      />
+    </main>
+  )
 }

--- a/app/invite/[code]/page.tsx
+++ b/app/invite/[code]/page.tsx
@@ -1,5 +1,9 @@
 import { createClient } from "@/lib/supabase/server"
 import { redirect, notFound } from "next/navigation"
+import {
+  SpectatorGameView,
+  type SpectatorGameData
+} from "@/components/spectator-game-view"
 
 async function ensureProfile(
   supabase: Awaited<ReturnType<typeof createClient>>,
@@ -21,7 +25,6 @@ async function ensureProfile(
       display_name: fallbackName
     })
     if (error) {
-      // If this fails, we still allow joining the game; profile can be fixed later.
       console.error("Error ensuring profile in invite route:", error)
     }
   }
@@ -38,13 +41,29 @@ export default async function InvitePage({
     data: { user }
   } = await supabase.auth.getUser()
 
+  const shortCode = code.trim().toLowerCase()
+
   if (!user) {
-    redirect(`/login?next=${encodeURIComponent(`/invite/${code}`)}`)
+    const { data: spectatorData, error } = await supabase.rpc(
+      "get_spectator_game",
+      { p_short_code: shortCode }
+    )
+
+    if (error || !spectatorData) {
+      notFound()
+    }
+
+    return (
+      <main id="main-content" tabIndex={-1}>
+        <SpectatorGameView
+          shortCode={shortCode}
+          initialData={spectatorData as SpectatorGameData}
+        />
+      </main>
+    )
   }
 
   await ensureProfile(supabase, user.id, user.email ?? null)
-
-  const shortCode = code.trim().toLowerCase()
 
   const { data: game, error: gameError } = await supabase
     .from("games")
@@ -52,7 +71,7 @@ export default async function InvitePage({
     .eq("short_code", shortCode)
     .single()
 
-  if (gameError || !game || game.status !== "active") {
+  if (gameError || !game) {
     notFound()
   }
 
@@ -67,6 +86,9 @@ export default async function InvitePage({
     redirect(`/game/${game.id}`)
   }
 
+  if (game.status !== "active") {
+    notFound()
+  }
+
   redirect(`/invite/${code}/join`)
 }
-

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,12 +26,18 @@ export default function LandingPage() {
           <CardTitle className="text-2xl">ChipCount</CardTitle>
           <CardDescription>
             Track poker games, calculate payouts, and see who&apos;s up over
-            time. Log in to start or join a game.
+            time. Start a quick game with no account, or log in for hosted
+            tables.
           </CardDescription>
         </CardHeader>
-        <CardContent>
-          <Link href="/login">
+        <CardContent className="space-y-3">
+          <Link href="/play">
             <Button className="w-full" size="lg">
+              Quick game (no account)
+            </Button>
+          </Link>
+          <Link href="/login">
+            <Button className="w-full" size="lg" variant="outline">
               Log in
             </Button>
           </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -36,8 +36,13 @@ export default function LandingPage() {
               Quick game (no account)
             </Button>
           </Link>
-          <Link href="/login">
+          <Link href="/login?signup=1">
             <Button className="w-full" size="lg" variant="outline">
+              Create account
+            </Button>
+          </Link>
+          <Link href="/login">
+            <Button className="w-full" size="lg" variant="ghost">
               Log in
             </Button>
           </Link>

--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import { Suspense } from "react"
+
+import { GameForm } from "@/components/game-form"
+import { PayoutStats } from "@/components/payout-stats"
+import { QuickGameActions } from "@/components/quick-game-actions"
+import { Skeleton } from "@/components/ui/skeleton"
+
+function PlayPageContent() {
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 px-4 py-8">
+      <QuickGameActions />
+      <div className="grid gap-6 lg:grid-cols-2">
+        <GameForm />
+        <PayoutStats />
+      </div>
+    </div>
+  )
+}
+
+function PlayPageSkeleton() {
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 px-4 py-8">
+      <Skeleton className="mx-auto h-24 w-full max-w-md" />
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Skeleton className="h-96" />
+        <Skeleton className="h-96" />
+      </div>
+    </div>
+  )
+}
+
+export default function PlayPage() {
+  return (
+    <main id="main-content" tabIndex={-1}>
+      <Suspense fallback={<PlayPageSkeleton />}>
+        <PlayPageContent />
+      </Suspense>
+    </main>
+  )
+}

--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -1,19 +1,54 @@
 "use client"
 
+import Link from "next/link"
 import { Suspense } from "react"
+import { ArrowLeft } from "lucide-react"
 
 import { GameForm } from "@/components/game-form"
 import { PayoutStats } from "@/components/payout-stats"
 import { QuickGameActions } from "@/components/quick-game-actions"
+import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 
 function PlayPageContent() {
   return (
-    <div className="mx-auto max-w-4xl space-y-6 px-4 py-8">
-      <QuickGameActions />
-      <div className="grid gap-6 lg:grid-cols-2">
-        <GameForm />
-        <PayoutStats />
+    <div className="flex min-h-screen flex-col">
+      <header className="border-b bg-background/80 backdrop-blur-sm sticky top-0 z-10">
+        <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-3">
+          <div className="flex items-center gap-3 min-w-0">
+            <Link href="/">
+              <Button variant="ghost" size="sm" className="shrink-0">
+                <ArrowLeft className="mr-1.5 h-4 w-4" />
+                Home
+              </Button>
+            </Link>
+            <div className="hidden sm:block h-4 w-px bg-border" />
+            <div className="min-w-0 hidden sm:block">
+              <p className="font-semibold text-sm truncate">Quick Game</p>
+              <p className="text-muted-foreground text-xs truncate">
+                No account needed
+              </p>
+            </div>
+          </div>
+          <QuickGameActions />
+        </div>
+      </header>
+
+      <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-6 sm:py-8">
+        <div className="mb-6 sm:mb-8">
+          <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+            Track &amp; settle up
+          </h1>
+          <p className="text-muted-foreground mt-1.5 max-w-2xl text-sm sm:text-base">
+            Enter player buy-ins and cash-outs below. Everything auto-saves to
+            the link — share it so anyone can view and edit.
+          </p>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-2 lg:items-start lg:gap-8">
+          <GameForm />
+          <PayoutStats />
+        </div>
       </div>
     </div>
   )
@@ -21,11 +56,16 @@ function PlayPageContent() {
 
 function PlayPageSkeleton() {
   return (
-    <div className="mx-auto max-w-4xl space-y-6 px-4 py-8">
-      <Skeleton className="mx-auto h-24 w-full max-w-md" />
-      <div className="grid gap-6 lg:grid-cols-2">
-        <Skeleton className="h-96" />
-        <Skeleton className="h-96" />
+    <div className="flex min-h-screen flex-col">
+      <div className="border-b px-4 py-3">
+        <Skeleton className="h-9 w-48" />
+      </div>
+      <div className="mx-auto w-full max-w-6xl space-y-6 px-4 py-8">
+        <Skeleton className="h-16 w-full max-w-lg" />
+        <div className="grid gap-6 lg:grid-cols-2">
+          <Skeleton className="h-[28rem]" />
+          <Skeleton className="h-[28rem]" />
+        </div>
       </div>
     </div>
   )

--- a/components/donut-chart.tsx
+++ b/components/donut-chart.tsx
@@ -12,6 +12,10 @@ import { useMemo } from "react"
 import { formatDollar } from "@/lib/utils"
 import chroma from "chroma-js"
 
+function shortChartLabel(value: string) {
+  return value.length > 12 ? `${value.slice(0, 11)}…` : value
+}
+
 export function DonutCharts({ payout }: { payout: PayoutSchema }) {
   const players = payout.players.toSorted((a, b) => b.net - a.net)
   const smallestNet = players[players.length - 1].net
@@ -107,8 +111,9 @@ export function DonutCharts({ payout }: { payout: PayoutSchema }) {
             dataKey="name"
             position="outside"
             offset={8}
-            className="fill-foreground"
+            className="fill-foreground text-xs"
             stroke="none"
+            formatter={(val: string) => shortChartLabel(val)}
           />
         </Pie>
 

--- a/components/game-form.tsx
+++ b/components/game-form.tsx
@@ -31,7 +31,7 @@ export function GameForm() {
   const [game, setGame] = useQueryState("game", {
     ...parseZipson,
     history: "replace",
-    throttleMs: 5000
+    throttleMs: 800
   })
 
   const form = useForm<GameSchema>({

--- a/components/game-form.tsx
+++ b/components/game-form.tsx
@@ -9,7 +9,7 @@ import {
   UseFieldArrayAppend,
   UseFieldArrayRemove
 } from "react-hook-form"
-import { X, Loader2 } from "lucide-react"
+import { X, Plus, Cloud } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
   Form,
@@ -21,6 +21,14 @@ import {
   FormMessage
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
 import { gameSchema, GameSchema, PlayerSchema } from "@/lib/schemas"
 import { formattedDateTime } from "@/lib/utils"
 import { useQueryState } from "nuqs"
@@ -58,44 +66,48 @@ export function GameForm() {
     return () => subscription.unsubscribe()
   }, [form, setGame])
 
-  async function onSubmit(values: GameSchema) {
-    setGame(values)
-  }
-
   return (
-    <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
-        <FormField
-          control={form.control}
-          name="description"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Description</FormLabel>
-              <FormControl>
-                <Input placeholder="Game description" {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <PlayerFields
-          form={form}
-          fields={fields}
-          append={append}
-          remove={remove}
-        />
-        <Button
-          type="submit"
-          className="w-full"
-          disabled={form.formState.isSubmitting}
-        >
-          {form.formState.isSubmitting && (
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-          )}
-          Submit
-        </Button>
-      </form>
-    </Form>
+    <Card className="h-full">
+      <CardHeader className="border-b">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardTitle>Game details</CardTitle>
+            <CardDescription className="mt-1">
+              Changes save automatically to the URL
+            </CardDescription>
+          </div>
+          <Badge variant="secondary" className="shrink-0">
+            <Cloud className="h-3 w-3" />
+            Auto-save
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="pt-6">
+        <Form {...form}>
+          <form className="space-y-6">
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Friday night game" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <PlayerFields
+              form={form}
+              fields={fields}
+              append={append}
+              remove={remove}
+            />
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
   )
 }
 
@@ -129,26 +141,37 @@ const PlayerField = ({
 const NumericPlayerField = ({
   control,
   name,
-  placeholder,
-  label
+  label,
+  className
 }: {
   control: Control<GameSchema>
   name: `players.${number}.cashIn` | `players.${number}.cashOut`
-  placeholder: string
   label: string
+  className?: string
 }) => (
   <FormField
     control={control}
     name={name}
     render={({ field }) => (
-      <FormItem className="w-32 sm:w-24">
+      <FormItem className={className}>
+        <FormLabel className="text-xs text-muted-foreground md:sr-only">
+          {label}
+        </FormLabel>
         <FormControl>
           <Input
             type="number"
-            placeholder={placeholder}
+            min={0}
+            step="0.01"
+            inputMode="decimal"
+            placeholder="0"
             aria-label={label}
+            className="tabular-nums"
             {...field}
-            onChange={(e) => field.onChange(e.target.valueAsNumber || 0)}
+            value={field.value === 0 ? "" : field.value}
+            onChange={(e) => {
+              const val = e.target.value
+              field.onChange(val === "" ? "" : e.target.valueAsNumber || 0)
+            }}
           />
         </FormControl>
         <FormMessage />
@@ -170,54 +193,88 @@ const PlayerFields = ({
   append: UseFieldArrayAppend<GameSchema, "players">
   remove: UseFieldArrayRemove
 }) => (
-  <div className="space-y-2">
-    <FormLabel className="grow">Players</FormLabel>
-    <FormDescription>
-      Prefix names with @ or $ to link to Venmo or Cashapp
-    </FormDescription>
-    {fields.map((field, index) => (
-      <div key={field.id} className="flex items-start space-x-2">
-        <PlayerField
-          control={form.control}
-          name={`players.${index}.name`}
-          placeholder={`Player ${index + 1}`}
-          label={`Player ${index + 1} name`}
-          className="grow"
-        />
-        <NumericPlayerField
-          control={form.control}
-          name={`players.${index}.cashIn`}
-          placeholder="In"
-          label={`Cash in for player ${index + 1}`}
-        />
-        <NumericPlayerField
-          control={form.control}
-          name={`players.${index}.cashOut`}
-          placeholder="Out"
-          label={`Cash out for player ${index + 1}`}
-        />
-        <Button
-          type="button"
-          variant="destructive"
-          size="icon"
-          aria-label={`Remove player ${index + 1}`}
-          onClick={() => remove(index)}
-          disabled={fields.length <= 2}
-        >
-          <X className="h-4 w-4" />
-        </Button>
-      </div>
-    ))}
+  <div className="space-y-3">
     <div>
-      <FormMessage>{form.formState.errors.players?.root?.message}</FormMessage>
+      <FormLabel>Players</FormLabel>
+      <FormDescription className="mt-1">
+        Prefix names with @ or $ for Venmo or Cash App links in payouts
+      </FormDescription>
     </div>
+
+    {/* Column headers — desktop only */}
+    <div className="hidden md:grid md:grid-cols-[1fr_5.5rem_5.5rem_2.25rem] md:gap-2 md:px-1">
+      <span className="text-muted-foreground text-xs font-medium">Name</span>
+      <span className="text-muted-foreground text-xs font-medium">Cash in</span>
+      <span className="text-muted-foreground text-xs font-medium">Cash out</span>
+      <span className="sr-only">Remove</span>
+    </div>
+
+    <div className="space-y-2">
+      {fields.map((field, index) => (
+        <div
+          key={field.id}
+          className="rounded-lg border bg-muted/30 p-3 md:border-0 md:bg-transparent md:p-0 md:rounded-none"
+        >
+          <div className="mb-2 flex items-center justify-between md:hidden">
+            <span className="text-muted-foreground text-xs font-medium">
+              Player {index + 1}
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-muted-foreground hover:text-destructive"
+              aria-label={`Remove player ${index + 1}`}
+              onClick={() => remove(index)}
+              disabled={fields.length <= 2}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+          <div className="grid gap-2 sm:grid-cols-[1fr_1fr_1fr] md:grid-cols-[1fr_5.5rem_5.5rem_2.25rem] md:items-start md:gap-2">
+            <PlayerField
+              control={form.control}
+              name={`players.${index}.name`}
+              placeholder={`Player ${index + 1}`}
+              label={`Player ${index + 1} name`}
+              className="sm:col-span-3 md:col-span-1"
+            />
+            <NumericPlayerField
+              control={form.control}
+              name={`players.${index}.cashIn`}
+              label="Cash in"
+            />
+            <NumericPlayerField
+              control={form.control}
+              name={`players.${index}.cashOut`}
+              label="Cash out"
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="hidden md:flex h-9 w-9 shrink-0 text-muted-foreground hover:text-destructive"
+              aria-label={`Remove player ${index + 1}`}
+              onClick={() => remove(index)}
+              disabled={fields.length <= 2}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      ))}
+    </div>
+
+    <FormMessage>{form.formState.errors.players?.root?.message}</FormMessage>
+
     <Button
       type="button"
       variant="outline"
       onClick={() => append({} as PlayerSchema)}
       className="w-full"
     >
-      Add Player
+      <Plus className="mr-2 h-4 w-4" />
+      Add player
     </Button>
   </div>
 )

--- a/components/game-session.tsx
+++ b/components/game-session.tsx
@@ -689,7 +689,7 @@ export function GameSession({
             <CardTitle>{game.description || "Game"}</CardTitle>
             <CardDescription>
               Game ID: <span className="font-mono">{game.short_code}</span> —
-              share so others can join
+              anyone can view the live table; sign in to join as a player
               <br />
               Invite link:{" "}
               <span className="font-mono break-all">{inviteUrl}</span>

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -43,7 +43,9 @@ export function LoginForm({ next }: { next?: string }) {
   const router = useRouter()
   const searchParams = useSearchParams()
   const nextPath = next ?? searchParams.get("next") ?? "/dashboard"
-  const [isSignUp, setIsSignUp] = useState(false)
+  const [isSignUp, setIsSignUp] = useState(
+    () => searchParams.get("signup") === "1"
+  )
   const [message, setMessage] = useState<{ type: "error" | "success"; text: string } | null>(null)
   const [googleLoading, setGoogleLoading] = useState(false)
 

--- a/components/negative-chart.tsx
+++ b/components/negative-chart.tsx
@@ -22,7 +22,7 @@ export function NegativeChart({ players }: { players: PlayerSchema[] }) {
   return (
     <ChartContainer
       config={chartConfig}
-      className="h-full max-h-[500px] min-h-[10px] w-full"
+      className="h-[220px] w-full"
     >
       <BarChart
         accessibilityLayer

--- a/components/payout-stats.tsx
+++ b/components/payout-stats.tsx
@@ -8,7 +8,14 @@ import { SlippageInfo } from "./slippage-info"
 import { useMemo } from "react"
 import { DonutCharts } from "./donut-chart"
 import { NegativeChart } from "./negative-chart"
-import { Card, CardContent } from "./ui/card"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "./ui/card"
+import { BarChart3 } from "lucide-react"
 
 export function PayoutStats() {
   const [game] = useQueryState("game", parseZipson)
@@ -23,27 +30,63 @@ export function PayoutStats() {
     return payout
   }, [game])
 
-  if (!payout) return
-
-  return (
-    <div className="space-y-5">
-      {Math.abs(payout.slippage) > 1e-9 && <SlippageInfo payout={payout} />}
-
-      <Card className="bg-secondary">
-        <CardContent className="flex w-full flex-col justify-around gap-5 md:flex-row">
-          <DonutCharts payout={payout} />
-          <NegativeChart players={payout.players} />
+  if (!payout) {
+    return (
+      <Card className="h-full border-dashed">
+        <CardHeader className="border-b">
+          <CardTitle className="flex items-center gap-2">
+            <BarChart3 className="h-5 w-5 text-muted-foreground" />
+            Settlements
+          </CardTitle>
+          <CardDescription>
+            Payouts appear here once you add at least two players with names
+            and cash amounts.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-1 flex-col pt-6">
+          <div className="flex flex-1 flex-col items-center justify-center rounded-lg border border-dashed bg-muted/20 py-16 text-center">
+            <BarChart3 className="text-muted-foreground/50 mb-3 h-10 w-10" />
+            <p className="text-muted-foreground text-sm font-medium">
+              Waiting for player data
+            </p>
+            <p className="text-muted-foreground/70 mt-1 max-w-xs text-xs">
+              Fill in names, buy-ins, and cash-outs on the left to see who owes
+              whom.
+            </p>
+          </div>
         </CardContent>
       </Card>
-      <div className="grid gap-5 md:grid-cols-2">
-        {payout.players.map((player) => (
-          <PlayerSummary
-            key={player.name}
-            player={player}
-            slippage={payout.slippage / payout.players.length}
-          />
-        ))}
-      </div>
-    </div>
+    )
+  }
+
+  return (
+    <Card className="h-full">
+      <CardHeader className="border-b">
+        <CardTitle>Settlements</CardTitle>
+        <CardDescription>
+          Who pays whom based on current numbers
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5 pt-6">
+        {Math.abs(payout.slippage) > 1e-9 && <SlippageInfo payout={payout} />}
+
+        <div className="rounded-lg border bg-muted/20 p-4 sm:p-5">
+          <div className="flex w-full flex-col justify-around gap-5 lg:flex-row">
+            <DonutCharts payout={payout} />
+            <NegativeChart players={payout.players} />
+          </div>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          {payout.players.map((player) => (
+            <PlayerSummary
+              key={player.name}
+              player={player}
+              slippage={payout.slippage / payout.players.length}
+            />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
   )
 }

--- a/components/quick-game-actions.tsx
+++ b/components/quick-game-actions.tsx
@@ -9,30 +9,21 @@ import { Button } from "@/components/ui/button"
 export function QuickGameActions() {
   const copyLink = () => {
     navigator.clipboard.writeText(window.location.href).then(
-      () => toast.success("Link copied to clipboard"),
-      () => toast.error("Failed to copy link.")
+      () => toast.success("Link copied"),
+      () => toast.error("Failed to copy link")
     )
   }
 
   return (
-    <div className="space-y-3 text-center">
-      <Button onClick={copyLink} variant="outline">
-        <LinkIcon className="mr-2 h-4 w-4" />
-        Copy link
+    <div className="flex items-center gap-2 shrink-0">
+      <Button onClick={copyLink} variant="outline" size="sm">
+        <LinkIcon className="mr-1.5 h-4 w-4" />
+        <span className="hidden sm:inline">Copy link</span>
+        <span className="sm:hidden">Copy</span>
       </Button>
-      <p className="text-muted-foreground text-sm">
-        This game lives in the link — share it to collaborate. Nothing is saved
-        to your account.
-      </p>
-      <p className="text-muted-foreground text-sm">
-        Want a persistent hosted table?{" "}
-        <Link
-          href="/login"
-          className="text-primary underline-offset-4 hover:underline"
-        >
-          Log in
-        </Link>
-      </p>
+      <Button asChild variant="ghost" size="sm" className="hidden md:inline-flex">
+        <Link href="/login?signup=1">Create account</Link>
+      </Button>
     </div>
   )
 }

--- a/components/quick-game-actions.tsx
+++ b/components/quick-game-actions.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import Link from "next/link"
+import { Link as LinkIcon } from "lucide-react"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+
+export function QuickGameActions() {
+  const copyLink = () => {
+    navigator.clipboard.writeText(window.location.href).then(
+      () => toast.success("Link copied to clipboard"),
+      () => toast.error("Failed to copy link.")
+    )
+  }
+
+  return (
+    <div className="space-y-3 text-center">
+      <Button onClick={copyLink} variant="outline">
+        <LinkIcon className="mr-2 h-4 w-4" />
+        Copy link
+      </Button>
+      <p className="text-muted-foreground text-sm">
+        This game lives in the link — share it to collaborate. Nothing is saved
+        to your account.
+      </p>
+      <p className="text-muted-foreground text-sm">
+        Want a persistent hosted table?{" "}
+        <Link
+          href="/login"
+          className="text-primary underline-offset-4 hover:underline"
+        >
+          Log in
+        </Link>
+      </p>
+    </div>
+  )
+}

--- a/components/spectator-game-view.tsx
+++ b/components/spectator-game-view.tsx
@@ -5,7 +5,10 @@ import Link from "next/link"
 import { createClient } from "@/lib/supabase/client"
 import { calcPayouts, formatDollar } from "@/lib/utils"
 import type { GameSchema } from "@/lib/schemas"
-import { PayoutStatsView } from "./payout-stats-view"
+import { PlayerSummary } from "./player-summary"
+import { SlippageInfo } from "./slippage-info"
+import { DonutCharts } from "./donut-chart"
+import { NegativeChart } from "./negative-chart"
 import {
   Card,
   CardContent,
@@ -13,7 +16,8 @@ import {
   CardHeader,
   CardTitle
 } from "./ui/card"
-import { Button } from "./ui/button"
+import { Button } from "@/components/ui/button"
+import { Badge } from "./ui/badge"
 import {
   Dialog,
   DialogContent,
@@ -22,7 +26,7 @@ import {
   DialogHeader,
   DialogTitle
 } from "./ui/dialog"
-import { Copy, Eye, Lock } from "lucide-react"
+import { ArrowLeft, Eye, Link as LinkIcon, Lock } from "lucide-react"
 import { toast } from "sonner"
 
 export type SpectatorGameData = {
@@ -56,16 +60,28 @@ function playerName(p: SpectatorGameData["players"][number]) {
   )
 }
 
+function statusBadge(status: "pending" | "approved" | "denied") {
+  switch (status) {
+    case "pending":
+      return <Badge variant="outline">Pending</Badge>
+    case "denied":
+      return <Badge variant="destructive">Denied</Badge>
+    default:
+      return null
+  }
+}
+
 export function SpectatorGameView({
   shortCode,
-  initialData
+  initialData,
+  isAuthenticated = false
 }: {
   shortCode: string
   initialData: SpectatorGameData
+  isAuthenticated?: boolean
 }) {
   const [data, setData] = useState(initialData)
   const [showSignInDialog, setShowSignInDialog] = useState(false)
-  const [copyFeedback, setCopyFeedback] = useState("")
 
   const inviteUrl =
     typeof window !== "undefined"
@@ -73,6 +89,7 @@ export function SpectatorGameView({
       : `/invite/${shortCode}`
 
   const loginUrl = `/login?next=${encodeURIComponent(`/invite/${shortCode}`)}`
+  const joinUrl = `/invite/${shortCode}/join`
 
   const fetchGame = useCallback(async () => {
     const supabase = createClient()
@@ -85,12 +102,14 @@ export function SpectatorGameView({
   }, [shortCode])
 
   useEffect(() => {
+    if (isAuthenticated) return
+
     const dismissed =
       localStorage.getItem(`${DISMISS_KEY_PREFIX}${shortCode}`) === "1"
     if (!dismissed) {
       setShowSignInDialog(true)
     }
-  }, [shortCode])
+  }, [shortCode, isAuthenticated])
 
   useEffect(() => {
     const interval = setInterval(fetchGame, 5000)
@@ -99,6 +118,7 @@ export function SpectatorGameView({
 
   const approved = data.players.filter((p) => p.status === "approved")
   const isClosed = data.game.status === "closed"
+  const gameLabel = data.game.description || "Game"
 
   const gameForPayout = useMemo((): GameSchema | null => {
     const guestsWithAmounts = data.guests.filter(
@@ -107,10 +127,7 @@ export function SpectatorGameView({
     if (approved.length + guestsWithAmounts.length < 2) return null
 
     const names = new Set<string>()
-    const makeName = (
-      base: string,
-      fallbackIndex?: number
-    ) => {
+    const makeName = (base: string, fallbackIndex?: number) => {
       let name = base
       let n = fallbackIndex ?? 0
       while (names.has(name)) {
@@ -131,8 +148,8 @@ export function SpectatorGameView({
         cashIn: p.cash_in,
         cashOut: p.cash_out
       })),
-      ...guestsWithAmounts.map((g) => ({
-        name: makeName(`${g.name} (guest)`),
+      ...guestsWithAmounts.map((g, i) => ({
+        name: makeName(g.name, i),
         cashIn: g.cash_in,
         cashOut: g.cash_out
       }))
@@ -156,136 +173,227 @@ export function SpectatorGameView({
 
   function copyInviteLink() {
     navigator.clipboard.writeText(inviteUrl)
-    setCopyFeedback("Invite link copied")
-    window.setTimeout(() => setCopyFeedback(""), 2000)
     toast.success("Link copied")
   }
 
+  const hasPlayers = data.players.length > 0 || data.guests.length > 0
+
   return (
-    <div className="mx-auto max-w-4xl space-y-6 pb-20">
-      <div
-        className="bg-primary text-primary-foreground sticky top-0 z-40 flex items-center justify-between gap-3 px-4 py-2 text-sm shadow-sm"
-        role="banner"
-      >
-        <span>Sign in to join this table</span>
-        <Button asChild size="sm" variant="secondary">
-          <Link href={loginUrl}>Sign in</Link>
-        </Button>
-      </div>
-
-      <Card>
-        <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
-          <div>
-            <div className="text-muted-foreground mb-1 flex items-center gap-1.5 text-sm">
-              <Eye className="h-4 w-4" />
-              Spectator view
+    <div className="flex min-h-screen flex-col">
+      <header className="border-b bg-background/80 backdrop-blur-sm sticky top-0 z-10">
+        <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-3">
+          <div className="flex items-center gap-3 min-w-0">
+            <Link href="/">
+              <Button variant="ghost" size="sm" className="shrink-0">
+                <ArrowLeft className="mr-1.5 h-4 w-4" />
+                Home
+              </Button>
+            </Link>
+            <div className="hidden sm:block h-4 w-px bg-border" />
+            <div className="min-w-0 hidden sm:block">
+              <p className="font-semibold text-sm truncate flex items-center gap-1.5">
+                <Eye className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                {gameLabel}
+              </p>
+              <p className="text-muted-foreground text-xs truncate">
+                Spectator view · {data.game.short_code}
+                {isClosed && " · Closed"}
+              </p>
             </div>
-            <CardTitle>{data.game.description || "Game"}</CardTitle>
-            <CardDescription>
-              Game ID:{" "}
-              <span className="font-mono">{data.game.short_code}</span>
-              {isClosed && (
-                <span className="ml-2 inline-flex items-center gap-1">
-                  <Lock className="h-3 w-3" />
-                  Session closed
-                </span>
-              )}
-            </CardDescription>
           </div>
-          <Button variant="outline" size="sm" onClick={copyInviteLink}>
-            <Copy className="mr-1 h-4 w-4" />
-            Copy link
-          </Button>
-        </CardHeader>
-        <div className="sr-only" aria-live="polite">
-          {copyFeedback}
+          <div className="flex items-center gap-2 shrink-0">
+            <Button onClick={copyInviteLink} variant="outline" size="sm">
+              <LinkIcon className="mr-1.5 h-4 w-4" />
+              <span className="hidden sm:inline">Copy link</span>
+              <span className="sm:hidden">Copy</span>
+            </Button>
+            <Button asChild size="sm">
+              {isAuthenticated ? (
+                <Link href={joinUrl}>Join table</Link>
+              ) : (
+                <Link href={loginUrl}>Sign in</Link>
+              )}
+            </Button>
+          </div>
         </div>
-      </Card>
+      </header>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Players & amounts</CardTitle>
-          <CardDescription>Live read-only view of the table</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-3">
-            {data.players.map((p, i) => (
-              <div
-                key={`${playerName(p)}-${i}`}
-                className="flex flex-wrap items-center gap-2 rounded border p-2"
-              >
-                <span className="font-medium">
-                  {playerName(p)}
-                  {p.status === "pending" && (
-                    <span className="text-muted-foreground ml-1 text-sm">
-                      (pending)
-                    </span>
-                  )}
-                  {p.status === "denied" && (
-                    <span className="text-muted-foreground ml-1 text-sm">
-                      (denied)
-                    </span>
-                  )}
-                </span>
-                {p.status === "approved" && (
-                  <span className="text-muted-foreground text-sm">
-                    In: {formatDollar(p.cash_in)} / Out:{" "}
-                    {formatDollar(p.cash_out)}
-                  </span>
-                )}
-              </div>
-            ))}
-            {data.guests.map((g) => (
-              <div
-                key={g.name}
-                className="flex flex-wrap items-center gap-2 rounded border p-2"
-              >
-                <span className="font-medium">
-                  {g.name}
-                  <span className="text-muted-foreground ml-1 text-sm">
-                    (guest)
-                  </span>
-                </span>
-                <span className="text-muted-foreground text-sm">
-                  In: {formatDollar(g.cash_in)} / Out:{" "}
-                  {formatDollar(g.cash_out)}
-                </span>
-              </div>
-            ))}
-            {data.players.length === 0 && data.guests.length === 0 && (
-              <p className="text-muted-foreground text-sm">No players yet.</p>
+      <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-6 sm:py-8">
+        <div className="mb-6 sm:mb-8">
+          <div className="flex flex-wrap items-center gap-2 mb-2">
+            <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+              {gameLabel}
+            </h1>
+            {isClosed && (
+              <Badge variant="secondary" className="gap-1">
+                <Lock className="h-3 w-3" />
+                Session closed
+              </Badge>
             )}
           </div>
-        </CardContent>
-      </Card>
+          <p className="text-muted-foreground max-w-2xl text-sm sm:text-base">
+            {isAuthenticated
+              ? "You're watching this table live. Join to participate, or keep viewing read-only."
+              : "Live read-only view. Sign in to request joining as a player."}
+          </p>
+        </div>
 
-      {payout && <PayoutStatsView payout={payout} />}
+        <div className="grid gap-6 lg:grid-cols-2 lg:gap-8 lg:items-start">
+          <Card className="h-full">
+            <CardHeader className="border-b">
+              <CardTitle>Players &amp; amounts</CardTitle>
+              <CardDescription>
+                Updates every few seconds
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="pt-4">
+              {!hasPlayers ? (
+                <p className="text-muted-foreground py-8 text-center text-sm">
+                  No players yet.
+                </p>
+              ) : (
+                <div className="space-y-1">
+                  <div className="text-muted-foreground hidden sm:grid sm:grid-cols-[1fr_5rem_5rem_auto] sm:gap-3 sm:px-2 sm:pb-2 text-xs font-medium">
+                    <span>Name</span>
+                    <span className="text-right">In</span>
+                    <span className="text-right">Out</span>
+                    <span className="sr-only">Status</span>
+                  </div>
+                  <div className="divide-y rounded-lg border">
+                    {data.players.map((p, i) => (
+                      <div
+                        key={`${playerName(p)}-${i}`}
+                        className="flex flex-col gap-1 px-3 py-3 sm:grid sm:grid-cols-[1fr_5rem_5rem_auto] sm:items-center sm:gap-3"
+                      >
+                        <div className="flex items-center gap-2 min-w-0">
+                          <span className="font-medium truncate">
+                            {playerName(p)}
+                          </span>
+                          {statusBadge(p.status)}
+                        </div>
+                        {p.status === "approved" ? (
+                          <>
+                            <span className="text-muted-foreground sm:text-right tabular-nums text-sm">
+                              <span className="sm:hidden text-xs">In: </span>
+                              {formatDollar(p.cash_in)}
+                            </span>
+                            <span className="text-muted-foreground sm:text-right tabular-nums text-sm">
+                              <span className="sm:hidden text-xs">Out: </span>
+                              {formatDollar(p.cash_out)}
+                            </span>
+                            <span className="hidden sm:block" />
+                          </>
+                        ) : (
+                          <span className="text-muted-foreground col-span-2 text-sm sm:col-span-3">
+                            Awaiting host approval
+                          </span>
+                        )}
+                      </div>
+                    ))}
+                    {data.guests.map((g) => (
+                      <div
+                        key={g.name}
+                        className="flex flex-col gap-1 px-3 py-3 sm:grid sm:grid-cols-[1fr_5rem_5rem_auto] sm:items-center sm:gap-3"
+                      >
+                        <div className="flex items-center gap-2 min-w-0">
+                          <span className="font-medium truncate">{g.name}</span>
+                          <Badge variant="outline">Guest</Badge>
+                        </div>
+                        <span className="text-muted-foreground sm:text-right tabular-nums text-sm">
+                          <span className="sm:hidden text-xs">In: </span>
+                          {formatDollar(g.cash_in)}
+                        </span>
+                        <span className="text-muted-foreground sm:text-right tabular-nums text-sm">
+                          <span className="sm:hidden text-xs">Out: </span>
+                          {formatDollar(g.cash_out)}
+                        </span>
+                        <span className="hidden sm:block" />
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
 
-      <Dialog
-        open={showSignInDialog}
-        onOpenChange={(open) => {
-          if (!open) dismissSignInDialog()
-          else setShowSignInDialog(true)
-        }}
-      >
-        <DialogContent showCloseButton={false}>
-          <DialogHeader>
-            <DialogTitle>Viewing as spectator</DialogTitle>
-            <DialogDescription>
-              You can watch this table live. Sign in to request joining as a
-              player.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter className="gap-2 sm:gap-0">
-            <Button variant="outline" onClick={dismissSignInDialog}>
-              Continue watching
-            </Button>
-            <Button asChild>
-              <Link href={loginUrl}>Sign in to join</Link>
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+          <Card className="h-full">
+            <CardHeader className="border-b">
+              <CardTitle>Settlements</CardTitle>
+              <CardDescription>
+                Who pays whom based on current numbers
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-5 pt-6">
+              {!payout ? (
+                <div className="flex flex-col items-center justify-center rounded-lg border border-dashed bg-muted/20 py-16 text-center">
+                  <p className="text-muted-foreground text-sm font-medium">
+                    Not enough data yet
+                  </p>
+                  <p className="text-muted-foreground/70 mt-1 max-w-xs text-xs">
+                    Settlements appear once at least two players have cash
+                    amounts.
+                  </p>
+                </div>
+              ) : (
+                <>
+                  {Math.abs(payout.slippage) > 1e-9 && (
+                    <SlippageInfo payout={payout} />
+                  )}
+
+                  <div className="rounded-lg border bg-muted/20 p-4 sm:p-5">
+                    <div className="grid gap-6 lg:grid-cols-2 lg:items-center">
+                      <DonutCharts payout={payout} />
+                      <div className="min-h-[220px] w-full">
+                        <NegativeChart players={payout.players} />
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    {[...payout.players]
+                      .sort((a, b) => a.name.localeCompare(b.name))
+                      .map((player) => (
+                        <PlayerSummary
+                          key={player.name}
+                          player={player}
+                          slippage={payout.slippage / payout.players.length}
+                        />
+                      ))}
+                  </div>
+                </>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      {!isAuthenticated && (
+        <Dialog
+          open={showSignInDialog}
+          onOpenChange={(open) => {
+            if (!open) dismissSignInDialog()
+            else setShowSignInDialog(true)
+          }}
+        >
+          <DialogContent showCloseButton={false}>
+            <DialogHeader>
+              <DialogTitle>Viewing as spectator</DialogTitle>
+              <DialogDescription>
+                You can watch this table live. Sign in to request joining as a
+                player.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter className="gap-2 sm:gap-0">
+              <Button variant="outline" onClick={dismissSignInDialog}>
+                Continue watching
+              </Button>
+              <Button asChild>
+                <Link href={loginUrl}>Sign in to join</Link>
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
     </div>
   )
 }

--- a/components/spectator-game-view.tsx
+++ b/components/spectator-game-view.tsx
@@ -1,0 +1,291 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import Link from "next/link"
+import { createClient } from "@/lib/supabase/client"
+import { calcPayouts, formatDollar } from "@/lib/utils"
+import type { GameSchema } from "@/lib/schemas"
+import { PayoutStatsView } from "./payout-stats-view"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "./ui/card"
+import { Button } from "./ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "./ui/dialog"
+import { Copy, Eye, Lock } from "lucide-react"
+import { toast } from "sonner"
+
+export type SpectatorGameData = {
+  game: {
+    id: string
+    short_code: string
+    description: string | null
+    status: "active" | "closed"
+  }
+  players: {
+    display_name: string | null
+    status: "pending" | "approved" | "denied"
+    cash_in: number
+    cash_out: number
+    venmo_handle: string | null
+  }[]
+  guests: {
+    name: string
+    cash_in: number
+    cash_out: number
+  }[]
+}
+
+const DISMISS_KEY_PREFIX = "chipcount-spectator-signin-dismissed-"
+
+function playerName(p: SpectatorGameData["players"][number]) {
+  return (
+    p.display_name ||
+    (p.venmo_handle ? `@${p.venmo_handle}` : null) ||
+    "Player"
+  )
+}
+
+export function SpectatorGameView({
+  shortCode,
+  initialData
+}: {
+  shortCode: string
+  initialData: SpectatorGameData
+}) {
+  const [data, setData] = useState(initialData)
+  const [showSignInDialog, setShowSignInDialog] = useState(false)
+  const [copyFeedback, setCopyFeedback] = useState("")
+
+  const inviteUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}/invite/${shortCode}`
+      : `/invite/${shortCode}`
+
+  const loginUrl = `/login?next=${encodeURIComponent(`/invite/${shortCode}`)}`
+
+  const fetchGame = useCallback(async () => {
+    const supabase = createClient()
+    const { data: result, error } = await supabase.rpc("get_spectator_game", {
+      p_short_code: shortCode
+    })
+    if (!error && result) {
+      setData(result as SpectatorGameData)
+    }
+  }, [shortCode])
+
+  useEffect(() => {
+    const dismissed =
+      localStorage.getItem(`${DISMISS_KEY_PREFIX}${shortCode}`) === "1"
+    if (!dismissed) {
+      setShowSignInDialog(true)
+    }
+  }, [shortCode])
+
+  useEffect(() => {
+    const interval = setInterval(fetchGame, 5000)
+    return () => clearInterval(interval)
+  }, [fetchGame])
+
+  const approved = data.players.filter((p) => p.status === "approved")
+  const isClosed = data.game.status === "closed"
+
+  const gameForPayout = useMemo((): GameSchema | null => {
+    const guestsWithAmounts = data.guests.filter(
+      (g) => g.cash_in !== 0 || g.cash_out !== 0
+    )
+    if (approved.length + guestsWithAmounts.length < 2) return null
+
+    const names = new Set<string>()
+    const makeName = (
+      base: string,
+      fallbackIndex?: number
+    ) => {
+      let name = base
+      let n = fallbackIndex ?? 0
+      while (names.has(name)) {
+        name = `${base}_${++n}`
+      }
+      names.add(name)
+      return name
+    }
+
+    const players = [
+      ...approved.map((p, i) => ({
+        name: makeName(
+          p.venmo_handle
+            ? `@${p.venmo_handle}`
+            : p.display_name || `Player_${i}`,
+          i
+        ),
+        cashIn: p.cash_in,
+        cashOut: p.cash_out
+      })),
+      ...guestsWithAmounts.map((g) => ({
+        name: makeName(`${g.name} (guest)`),
+        cashIn: g.cash_in,
+        cashOut: g.cash_out
+      }))
+    ]
+
+    return {
+      description: data.game.description || undefined,
+      players
+    }
+  }, [approved, data.game.description, data.guests])
+
+  const payout = useMemo(
+    () => (gameForPayout ? calcPayouts(gameForPayout) : null),
+    [gameForPayout]
+  )
+
+  function dismissSignInDialog() {
+    localStorage.setItem(`${DISMISS_KEY_PREFIX}${shortCode}`, "1")
+    setShowSignInDialog(false)
+  }
+
+  function copyInviteLink() {
+    navigator.clipboard.writeText(inviteUrl)
+    setCopyFeedback("Invite link copied")
+    window.setTimeout(() => setCopyFeedback(""), 2000)
+    toast.success("Link copied")
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 pb-20">
+      <div
+        className="bg-primary text-primary-foreground sticky top-0 z-40 flex items-center justify-between gap-3 px-4 py-2 text-sm shadow-sm"
+        role="banner"
+      >
+        <span>Sign in to join this table</span>
+        <Button asChild size="sm" variant="secondary">
+          <Link href={loginUrl}>Sign in</Link>
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
+          <div>
+            <div className="text-muted-foreground mb-1 flex items-center gap-1.5 text-sm">
+              <Eye className="h-4 w-4" />
+              Spectator view
+            </div>
+            <CardTitle>{data.game.description || "Game"}</CardTitle>
+            <CardDescription>
+              Game ID:{" "}
+              <span className="font-mono">{data.game.short_code}</span>
+              {isClosed && (
+                <span className="ml-2 inline-flex items-center gap-1">
+                  <Lock className="h-3 w-3" />
+                  Session closed
+                </span>
+              )}
+            </CardDescription>
+          </div>
+          <Button variant="outline" size="sm" onClick={copyInviteLink}>
+            <Copy className="mr-1 h-4 w-4" />
+            Copy link
+          </Button>
+        </CardHeader>
+        <div className="sr-only" aria-live="polite">
+          {copyFeedback}
+        </div>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Players & amounts</CardTitle>
+          <CardDescription>Live read-only view of the table</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {data.players.map((p, i) => (
+              <div
+                key={`${playerName(p)}-${i}`}
+                className="flex flex-wrap items-center gap-2 rounded border p-2"
+              >
+                <span className="font-medium">
+                  {playerName(p)}
+                  {p.status === "pending" && (
+                    <span className="text-muted-foreground ml-1 text-sm">
+                      (pending)
+                    </span>
+                  )}
+                  {p.status === "denied" && (
+                    <span className="text-muted-foreground ml-1 text-sm">
+                      (denied)
+                    </span>
+                  )}
+                </span>
+                {p.status === "approved" && (
+                  <span className="text-muted-foreground text-sm">
+                    In: {formatDollar(p.cash_in)} / Out:{" "}
+                    {formatDollar(p.cash_out)}
+                  </span>
+                )}
+              </div>
+            ))}
+            {data.guests.map((g) => (
+              <div
+                key={g.name}
+                className="flex flex-wrap items-center gap-2 rounded border p-2"
+              >
+                <span className="font-medium">
+                  {g.name}
+                  <span className="text-muted-foreground ml-1 text-sm">
+                    (guest)
+                  </span>
+                </span>
+                <span className="text-muted-foreground text-sm">
+                  In: {formatDollar(g.cash_in)} / Out:{" "}
+                  {formatDollar(g.cash_out)}
+                </span>
+              </div>
+            ))}
+            {data.players.length === 0 && data.guests.length === 0 && (
+              <p className="text-muted-foreground text-sm">No players yet.</p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {payout && <PayoutStatsView payout={payout} />}
+
+      <Dialog
+        open={showSignInDialog}
+        onOpenChange={(open) => {
+          if (!open) dismissSignInDialog()
+          else setShowSignInDialog(true)
+        }}
+      >
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>Viewing as spectator</DialogTitle>
+            <DialogDescription>
+              You can watch this table live. Sign in to request joining as a
+              player.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button variant="outline" onClick={dismissSignInDialog}>
+              Continue watching
+            </Button>
+            <Button asChild>
+              <Link href={loginUrl}>Sign in to join</Link>
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/supabase/migrations/00017_spectator_rpc.sql
+++ b/supabase/migrations/00017_spectator_rpc.sql
@@ -1,0 +1,68 @@
+-- Read-only spectator access for invite links (anon + authenticated)
+create or replace function public.get_spectator_game(p_short_code text)
+returns json
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_game record;
+  v_result json;
+begin
+  select id, short_code, description, status
+  into v_game
+  from public.games
+  where lower(trim(short_code)) = lower(trim(p_short_code))
+    and status in ('active', 'closed');
+
+  if not found then
+    return null;
+  end if;
+
+  select json_build_object(
+    'game', json_build_object(
+      'id', v_game.id,
+      'short_code', v_game.short_code,
+      'description', v_game.description,
+      'status', v_game.status
+    ),
+    'players', coalesce((
+      select json_agg(
+        json_build_object(
+          'display_name', coalesce(gp.display_name, pr.display_name),
+          'status', gp.status,
+          'cash_in', coalesce(gp.cash_in, 0),
+          'cash_out', coalesce(gp.cash_out, 0),
+          'venmo_handle', pr.venmo_handle
+        )
+      )
+      from (
+        select gp.display_name, gp.status, gp.cash_in, gp.cash_out, gp.user_id
+        from public.game_players gp
+        where gp.game_id = v_game.id
+        order by gp.status, coalesce(gp.display_name, gp.user_id::text)
+      ) gp
+      left join public.profiles pr on pr.id = gp.user_id
+    ), '[]'::json),
+    'guests', coalesce((
+      select json_agg(
+        json_build_object(
+          'name', gg.name,
+          'cash_in', coalesce(gg.cash_in, 0),
+          'cash_out', coalesce(gg.cash_out, 0)
+        )
+      )
+      from (
+        select name, cash_in, cash_out
+        from public.game_guests
+        where game_id = v_game.id
+        order by name
+      ) gg
+    ), '[]'::json)
+  ) into v_result;
+
+  return v_result;
+end;
+$$;
+
+grant execute on function public.get_spectator_game(text) to anon, authenticated;


### PR DESCRIPTION
## Summary
- Add read-only spectator view on `/invite/{code}` for guests and logged-in non-participants (join is opt-in)
- Add ephemeral `/play` quick games with URL-embedded state and landing page CTAs
- Polish spectator and play page layouts with balanced side-by-side cards
- Add `get_spectator_game` RPC migration for anonymous read access

## Test plan
- [ ] Open `/invite/{code}` logged out — see read-only spectator view, no join redirect
- [ ] Open `/invite/{code}` logged in but not in game — same spectator view with "Join table" CTA
- [ ] Open `/` — Quick game, Create account, and Log in buttons work
- [ ] Open `/play` — form auto-saves to URL, settlements update side-by-side
- [ ] Apply migration `00017_spectator_rpc.sql` to Supabase before testing spectator RPC
- [ ] `npm run build` passes


Made with [Cursor](https://cursor.com)